### PR TITLE
Indent multiline output properly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 use ansi_term::{Color, Style};
 use chrono::{DateTime, Local};
-use std::{fmt, io, io::Write as _};
+use std::sync::Mutex;
+use std::{
+    fmt::{self, Write as _},
+    io,
+    io::Write as _,
+};
+
 use tracing::{
     field::{Field, Visit},
     span::{Attributes, Id},
@@ -16,6 +22,7 @@ pub struct HierarchicalLayer {
     stdout: io::Stdout,
     indent_amount: usize,
     ansi: bool,
+    buf: Mutex<String>,
 }
 
 struct Data {
@@ -24,7 +31,7 @@ struct Data {
 }
 
 struct FmtEvent<'a> {
-    stdout: io::StdoutLock<'a>,
+    buf: &'a mut String,
     comma: bool,
 }
 
@@ -48,19 +55,26 @@ impl Visit for Data {
 impl<'a> Visit for FmtEvent<'a> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         write!(
-            &mut self.stdout,
+            self.buf,
             "{comma} ",
             comma = if self.comma { "," } else { "" },
         )
         .unwrap();
         let name = field.name();
         if name == "message" {
-            write!(&mut self.stdout, "{:?}", value).unwrap();
+            write!(self.buf, "{:?}", value).unwrap();
             self.comma = true;
         } else {
-            write!(&mut self.stdout, "{}={:?}", name, value).unwrap();
+            write!(self.buf, "{}={:?}", name, value).unwrap();
             self.comma = true;
         }
+    }
+}
+
+impl<'a> FmtEvent<'a> {
+    fn print(&mut self, outer_buf: &mut String, indent: usize, indent_amount: usize) {
+        let indented = indent_block(&self.buf, indent, indent_amount);
+        outer_buf.push_str(&indented);
     }
 }
 
@@ -79,6 +93,19 @@ impl<'a> fmt::Display for ColorLevel<'a> {
     }
 }
 
+fn indent_block(block: &str, indent: usize, indent_amount: usize) -> String {
+    let lines: Vec<_> = block.lines().collect();
+    let indent_spaces = indent * indent_amount;
+    let mut buf = String::with_capacity(block.len() + (lines.len() * indent_spaces));
+    let indent_str = String::from(" ").repeat(indent_spaces);
+    for line in lines {
+        buf.push_str(&indent_str);
+        buf.push_str(line);
+        buf.push('\n');
+    }
+    buf
+}
+
 impl HierarchicalLayer {
     pub fn new(indent_amount: usize) -> Self {
         let ansi = atty::is(atty::Stream::Stdout);
@@ -86,6 +113,7 @@ impl HierarchicalLayer {
             indent_amount,
             stdout: io::stdout(),
             ansi,
+            buf: Mutex::new(String::new()),
         }
     }
 
@@ -103,10 +131,10 @@ impl HierarchicalLayer {
 
     fn print_kvs<'a, I, K, V>(
         &self,
-        writer: &mut impl io::Write,
+        buf: &mut impl fmt::Write,
         kvs: I,
         leading: &str,
-    ) -> io::Result<()>
+    ) -> fmt::Result
     where
         I: IntoIterator<Item = (K, V)>,
         K: AsRef<str> + 'a,
@@ -115,7 +143,7 @@ impl HierarchicalLayer {
         let mut kvs = kvs.into_iter();
         if let Some((k, v)) = kvs.next() {
             write!(
-                writer,
+                buf,
                 "{}{}={}",
                 leading,
                 // Style::new().fg(Color::Purple).bold().paint(k.as_ref()),
@@ -125,19 +153,12 @@ impl HierarchicalLayer {
         }
         for (k, v) in kvs {
             write!(
-                writer,
+                buf,
                 ", {}={}",
                 // Style::new().fg(Color::Purple).bold().paint(k.as_ref()),
                 k.as_ref(),
                 v
             )?;
-        }
-        Ok(())
-    }
-
-    fn print_indent(&self, writer: &mut impl io::Write, indent: usize) -> io::Result<()> {
-        for _ in 0..(indent * self.indent_amount) {
-            write!(writer, " ")?;
         }
         Ok(())
     }
@@ -154,47 +175,50 @@ where
     }
 
     fn on_enter(&self, id: &tracing::Id, ctx: Context<S>) {
-        let mut stdout = self.stdout.lock();
         let span = ctx.span(&id).expect("in on_enter but span does not exist");
         let ext = span.extensions();
         let data = ext.get::<Data>().expect("span does not have data");
 
+        let mut buf = self.buf.lock().unwrap();
+        let mut current_buf = String::new();
+
         let indent = ctx.scope().collect::<Vec<_>>().len() - 1;
-        self.print_indent(&mut stdout, indent)
-            .expect("Unable to write to stdout");
 
         write!(
-            &mut stdout,
+            current_buf,
             "{name}",
             name = self.styled(Style::new().fg(Color::Green).bold(), span.metadata().name())
         )
         .unwrap();
         write!(
-            &mut stdout,
+            current_buf,
             "{}",
             self.styled(Style::new().fg(Color::Green).bold(), "{") // Style::new().fg(Color::Green).dimmed().paint("{")
         )
         .unwrap();
-        self.print_kvs(&mut stdout, data.kvs.iter().map(|(k, v)| (k, v)), "")
+        self.print_kvs(&mut current_buf, data.kvs.iter().map(|(k, v)| (k, v)), "")
             .unwrap();
         write!(
-            &mut stdout,
+            current_buf,
             "{}",
             self.styled(Style::new().fg(Color::Green).bold(), "}") // Style::new().dimmed().paint("}")
         )
         .unwrap();
-        writeln!(&mut stdout).unwrap();
+        writeln!(current_buf).unwrap();
+        let indented = indent_block(&current_buf, indent, self.indent_amount);
+        buf.push_str(&indented);
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<S>) {
-        let mut stdout = self.stdout.lock();
+        let mut buf = self.buf.lock().unwrap();
+        let mut event_buf = String::new();
         // printing the indentation
-        if let Some(_) = ctx.current_span().id() {
+        let indent = if let Some(_) = ctx.current_span().id() {
             // size hint isn't implemented on Scope.
-            let indent = ctx.scope().collect::<Vec<_>>().len();
-            self.print_indent(&mut stdout, indent)
-                .expect("Unable to write to stdout");
-        }
+            ctx.scope().collect::<Vec<_>>().len()
+        } else {
+            0
+        };
 
         // check if this event occurred in the context of a span.
         // if it has, get the start time of this span.
@@ -222,7 +246,7 @@ where
                 level.to_string()
             };
             write!(
-                &mut stdout,
+                &mut event_buf,
                 "{timestamp}{unit} {level}",
                 timestamp = self.styled(
                     Style::new().dimmed(),
@@ -231,15 +255,22 @@ where
                 unit = self.styled(Style::new().dimmed(), "ms"),
                 level = level,
             )
-            .expect("Unable to write to stdout");
+            .expect("Unable to write to buffer");
         }
         let mut visitor = FmtEvent {
-            stdout,
             comma: false,
+            buf: &mut event_buf,
         };
         event.record(&mut visitor);
-        writeln!(&mut visitor.stdout).unwrap();
+        buf.reserve(visitor.buf.len());
+        writeln!(&mut visitor.buf).unwrap();
+        visitor.print(&mut buf, indent, self.indent_amount);
     }
 
-    fn on_close(&self, _: Id, _: Context<S>) {}
+    fn on_close(&self, _id: Id, _ctx: Context<S>) {
+        let mut stdout = self.stdout.lock();
+        let mut buf = self.buf.lock().unwrap();
+        write!(stdout, "{}", buf).unwrap();
+        buf.clear();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use ansi_term::{Color, Style};
 use chrono::{DateTime, Local};
-use std::ops::DerefMut as _;
 use std::sync::Mutex;
 use std::{
     fmt::{self, Write as _},
@@ -173,23 +172,10 @@ impl HierarchicalLayer {
     {
         let mut kvs = kvs.into_iter();
         if let Some((k, v)) = kvs.next() {
-            write!(
-                buf,
-                "{}{}={}",
-                leading,
-                // Style::new().fg(Color::Purple).bold().paint(k.as_ref()),
-                k.as_ref(),
-                v
-            )?;
+            write!(buf, "{}{}={}", leading, k.as_ref(), v)?;
         }
         for (k, v) in kvs {
-            write!(
-                buf,
-                ", {}={}",
-                // Style::new().fg(Color::Purple).bold().paint(k.as_ref()),
-                k.as_ref(),
-                v
-            )?;
+            write!(buf, ", {}={}", k.as_ref(), v)?;
         }
         Ok(())
     }
@@ -211,10 +197,10 @@ where
         let data = ext.get::<Data>().expect("span does not have data");
 
         let mut guard = self.bufs.lock().unwrap();
-        let bufs = guard.deref_mut();
+        let bufs = &mut *guard;
         let mut current_buf = &mut bufs.current_buf;
 
-        let indent = ctx.scope().collect::<Vec<_>>().len() - 1;
+        let indent = ctx.scope().count() - 1;
 
         write!(
             current_buf,
@@ -244,12 +230,12 @@ where
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<S>) {
         let mut guard = self.bufs.lock().unwrap();
-        let mut bufs = guard.deref_mut();
+        let mut bufs = &mut *guard;
         let mut event_buf = &mut bufs.current_buf;
         // printing the indentation
-        let indent = if let Some(_) = ctx.current_span().id() {
+        let indent = if ctx.current_span().id().is_some() {
             // size hint isn't implemented on Scope.
-            ctx.scope().collect::<Vec<_>>().len()
+            ctx.scope().count()
         } else {
             0
         };


### PR DESCRIPTION
This PR makes it so that multiline output (such as if a span/event has pretty-printed output) are indented properly.
Basically it just writes output to a buffer instead of straight to stdout, then indents the contents of the buffer, then later writes it to stdout.

