### PR TITLE
Add option to draw indentation lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@ const LINE_BRANCH: &str = "├";
 
 #[derive(Debug)]
 struct Config {
-    pub ansi: bool,
-    pub indent_lines: bool,
-    pub indent_amount: usize,
+    ansi: bool,
+    indent_lines: bool,
+    indent_amount: usize,
 }
 
 impl Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,8 +185,7 @@ impl HierarchicalLayer {
     fn flush(&self) {
         let mut stdout = self.stdout.lock();
         let mut bufs = self.bufs.lock().unwrap();
-        write!(stdout, "{}", &bufs.main_buf).unwrap();
-        bufs.main_buf.clear();
+        bufs.flush_main_buf(&mut stdout);
     }
 }
 
@@ -301,5 +300,7 @@ where
         bufs.flush_current_buf(self.stdout.lock());
     }
 
-    fn on_close(&self, _id: Id, _ctx: Context<S>) {}
+    fn on_close(&self, _id: Id, _ctx: Context<S>) {
+        self.flush();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,8 @@ impl HierarchicalLayer {
         }
     }
 
-    pub fn with_ansi(&mut self, ansi: bool) -> &mut Self {
-        self.ansi = ansi;
-        self
+    pub fn with_ansi(self, ansi: bool) -> Self {
+        Self { ansi, ..self }
     }
 
     fn styled(&self, style: Style, text: impl AsRef<str>) -> String {
@@ -180,18 +179,6 @@ impl HierarchicalLayer {
             write!(buf, ", {}={}", k.as_ref(), v)?;
         }
         Ok(())
-    }
-
-    fn flush(&self) {
-        let mut stdout = self.stdout.lock();
-        let mut bufs = self.bufs.lock().unwrap();
-        bufs.flush_main_buf(&mut stdout);
-    }
-}
-
-impl Drop for HierarchicalLayer {
-    fn drop(&mut self) {
-        self.flush();
     }
 }
 
@@ -300,7 +287,5 @@ where
         bufs.flush_current_buf(self.stdout.lock());
     }
 
-    fn on_close(&self, _id: Id, _ctx: Context<S>) {
-        self.flush();
-    }
+    fn on_close(&self, _id: Id, _ctx: Context<S>) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,9 @@ impl HierarchicalLayer {
         }
     }
 
-    pub fn with_ansi(self, ansi: bool) -> Self {
-        Self { ansi, ..self }
+    pub fn with_ansi(&mut self, ansi: bool) -> &mut Self {
+        self.ansi = ansi;
+        self
     }
 
     fn styled(&self, style: Style, text: impl AsRef<str>) -> String {
@@ -179,6 +180,19 @@ impl HierarchicalLayer {
             write!(buf, ", {}={}", k.as_ref(), v)?;
         }
         Ok(())
+    }
+
+    fn flush(&self) {
+        let mut stdout = self.stdout.lock();
+        let mut bufs = self.bufs.lock().unwrap();
+        write!(stdout, "{}", &bufs.main_buf).unwrap();
+        bufs.main_buf.clear();
+    }
+}
+
+impl Drop for HierarchicalLayer {
+    fn drop(&mut self) {
+        self.flush();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,41 @@ const LINE_VERT: &str = "│";
 const LINE_HORIZ: &str = "─";
 const LINE_HORIZ_THICK: &str = "━";
 const LINE_BRANCH: &str = "┝";
-#[allow(unused)]
-const LINE_LEAF: &str = "┕";
+
+#[derive(Debug)]
+struct Config {
+    pub ansi: bool,
+    pub indent_lines: bool,
+    pub indent_amount: usize,
+}
+
+impl Config {
+    fn with_ansi(self, ansi: bool) -> Self {
+        Self { ansi, ..self }
+    }
+    fn with_indent_lines(self, indent_lines: bool) -> Self {
+        Self {
+            indent_lines,
+            ..self
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ansi: true,
+            indent_lines: false,
+            indent_amount: 2,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct HierarchicalLayer {
     stdout: io::Stdout,
-    indent_amount: usize,
-    indent_lines: bool,
-    ansi: bool,
     bufs: Mutex<Buffers>,
+    config: Config,
 }
 
 #[derive(Debug)]
@@ -56,19 +81,13 @@ impl Buffers {
         self.indent_buf.clear();
     }
 
-    fn indent_current(
-        &mut self,
-        indent: usize,
-        indent_amount: usize,
-        indent_lines: bool,
-        is_span: bool,
-    ) {
+    fn indent_current(&mut self, indent: usize, config: &Config, is_span: bool) {
         indent_block(
             &mut self.current_buf,
             &mut self.indent_buf,
             indent,
-            indent_amount,
-            indent_lines,
+            config.indent_amount,
+            config.indent_lines,
             is_span,
         );
         self.current_buf.clear();
@@ -118,10 +137,9 @@ impl<'a> Visit for FmtEvent<'a> {
 }
 
 impl<'a> FmtEvent<'a> {
-    fn finish(&mut self, indent: usize, indent_amount: usize, indent_lines: bool) {
+    fn finish(&mut self, indent: usize, config: &Config) {
         self.bufs.current_buf.push('\n');
-        self.bufs
-            .indent_current(indent, indent_amount, indent_lines, false);
+        self.bufs.indent_current(indent, config, false);
         self.bufs.flush_indent_buf();
     }
 }
@@ -141,6 +159,70 @@ impl<'a> fmt::Display for ColorLevel<'a> {
     }
 }
 
+fn indent_block_with_lines(
+    lines: &[&str],
+    buf: &mut String,
+    indent: usize,
+    indent_amount: usize,
+    is_span: bool,
+) {
+    let indent_spaces = indent * indent_amount;
+    if lines.len() == 0 {
+        return;
+    } else if indent_spaces == 0 {
+        for line in lines {
+            buf.push_str(line);
+            buf.push('\n');
+        }
+        return;
+    }
+    let mut s = String::with_capacity(indent_spaces);
+
+    // instead of using all spaces to indent, draw a vertical line at every indent level
+    // up until the last indent
+    for i in 0..(indent_spaces - indent_amount) {
+        if i % indent_amount == 0 {
+            s.push_str(LINE_VERT);
+        } else {
+            s.push(' ');
+        }
+    }
+
+    buf.push_str(&s);
+    buf.push_str(LINE_BRANCH);
+
+    // draw thicker horizontal lines for spans, to distinguish them visually
+    let horiz = if is_span {
+        LINE_HORIZ_THICK
+    } else {
+        LINE_HORIZ
+    };
+
+    // add `indent_amount - 1` horizontal lines before the span/event
+    for _ in 0..(indent_amount - 1) {
+        buf.push_str(horiz);
+    }
+    buf.push_str(&lines[0]);
+    buf.push('\n');
+
+    // add the rest of the indentation, since we don't want to draw horizontal lines
+    // for subsequent lines
+    for i in 0..indent_amount {
+        if i % indent_amount == 0 {
+            s.push_str(LINE_VERT);
+        } else {
+            s.push(' ');
+        }
+    }
+
+    // add all of the actual content, with each line preceded by the indent string
+    for line in &lines[1..] {
+        buf.push_str(&s);
+        buf.push_str(line);
+        buf.push('\n');
+    }
+}
+
 fn indent_block(
     block: &mut String,
     buf: &mut String,
@@ -149,52 +231,11 @@ fn indent_block(
     indent_lines: bool,
     is_span: bool,
 ) {
-    let lines: Vec<_> = block.lines().collect();
+    let lines: Vec<&str> = block.lines().collect();
     let indent_spaces = indent * indent_amount;
     buf.reserve(block.len() + (lines.len() * indent_spaces));
     if indent_lines {
-        if lines.len() == 0 {
-            return;
-        } else if indent_spaces == 0 {
-            for line in &lines {
-                buf.push_str(line);
-                buf.push('\n');
-            }
-            return;
-        }
-        let mut s = String::with_capacity(indent_spaces);
-        for i in 0..(indent_spaces.saturating_sub(indent_amount)) {
-            if i % indent_amount == 0 {
-                s.push_str(LINE_VERT);
-            } else {
-                s.push(' ');
-            }
-        }
-        buf.push_str(&s);
-        buf.push_str(LINE_BRANCH);
-        let horiz = if is_span {
-            LINE_HORIZ_THICK
-        } else {
-            LINE_HORIZ
-        };
-        for _ in 0..(indent_amount.saturating_sub(1)) {
-            buf.push_str(horiz);
-        }
-        buf.push_str(&lines[0]);
-        buf.push('\n');
-
-        for i in 0..indent_amount {
-            if i % indent_amount == 0 {
-                s.push_str(LINE_VERT);
-            } else {
-                s.push(' ');
-            }
-        }
-        for line in &lines[1..] {
-            buf.push_str(&s);
-            buf.push_str(line);
-            buf.push('\n');
-        }
+        indent_block_with_lines(&lines, buf, indent, indent_amount, is_span);
     } else {
         let indent_str = String::from(" ").repeat(indent_spaces);
         for line in lines {
@@ -208,28 +249,34 @@ fn indent_block(
 impl HierarchicalLayer {
     pub fn new(indent_amount: usize) -> Self {
         let ansi = atty::is(atty::Stream::Stdout);
-        Self {
-            indent_amount,
-            indent_lines: false,
-            stdout: io::stdout(),
+        let config = Config {
             ansi,
+            indent_amount,
+            ..Default::default()
+        };
+        Self {
+            stdout: io::stdout(),
             bufs: Mutex::new(Buffers::new()),
+            config,
         }
     }
 
     pub fn with_ansi(self, ansi: bool) -> Self {
-        Self { ansi, ..self }
+        Self {
+            config: self.config.with_ansi(ansi),
+            ..self
+        }
     }
 
     pub fn with_indent_lines(self, indent_lines: bool) -> Self {
         Self {
-            indent_lines,
+            config: self.config.with_indent_lines(indent_lines),
             ..self
         }
     }
 
     fn styled(&self, style: Style, text: impl AsRef<str>) -> String {
-        if self.ansi {
+        if self.config.ansi {
             style.paint(text.as_ref()).to_string()
         } else {
             text.as_ref().to_string()
@@ -300,7 +347,7 @@ where
         )
         .unwrap();
 
-        bufs.indent_current(indent, self.indent_amount, self.indent_lines, true);
+        bufs.indent_current(indent, &self.config, true);
         bufs.flush_indent_buf();
         bufs.flush_current_buf(self.stdout.lock());
     }
@@ -348,7 +395,7 @@ where
             .expect("Unable to write to buffer");
         }
         let level = event.metadata().level();
-        let level = if self.ansi {
+        let level = if self.config.ansi {
             ColorLevel(level).to_string()
         } else {
             level.to_string()
@@ -359,7 +406,7 @@ where
             bufs: &mut bufs,
         };
         event.record(&mut visitor);
-        visitor.finish(indent, self.indent_amount, self.indent_lines);
+        visitor.finish(indent, &self.config);
         bufs.flush_current_buf(self.stdout.lock());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use ansi_term::{Color, Style};
 use chrono::{DateTime, Local};
-use std::ops::DerefMut as _;
 use std::sync::Mutex;
 use std::{
     fmt::{self, Write as _},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use ansi_term::{Color, Style};
 use chrono::{DateTime, Local};
+use std::ops::DerefMut as _;
 use std::sync::Mutex;
 use std::{
     fmt::{self, Write as _},


### PR DESCRIPTION
This adds an option to draw indentation lines, similar to what is described in #4.

Here's what it looks like:
<img width="665" alt="Screen Shot 2020-06-23 at 4 09 14 PM" src="https://user-images.githubusercontent.com/17734409/85933296-7af0c180-b8a3-11ea-9c4d-2f499f74b0c0.png">

It could probably use some more polish, but I figure it might be good enough for an initial implementation.
