### PR TITLE
Remove brackets and `message` field name from rendered message

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, instrument, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -33,6 +33,16 @@ fn main() {
     peer2.in_scope(|| {
         std::thread::sleep(std::time::Duration::from_millis(300));
         debug!("connected");
+    });
+    let peer3 = span!(
+        Level::TRACE,
+        "foomp",
+        normal_var = 43,
+        "{} <- format string",
+        42
+    );
+    peer3.in_scope(|| {
+        error!("hello");
     });
     peer1.in_scope(|| {
         warn!(algo = "xor", "weak encryption requested");

--- a/examples/basic.stdout
+++ b/examples/basic.stdout
@@ -1,35 +1,40 @@
-1:mainbasic::hierarchical-example{version=0.1}
-1:main├┐basic::hierarchical-example{version=0.1}
-1:main│└┐basic::server{host="localhost", port=8080}
+1:mainbasic::hierarchical-example version=0.1
+1:main├┐basic::hierarchical-example version=0.1
+1:main│└┐basic::server host="localhost", port=8080
 1:main│ ├─ms INFO basic starting
 1:main│ ├─ms INFO basic listening
-1:main│ ├┐basic::server{host="localhost", port=8080}
-1:main│ │└┐basic::conn{peer_addr="82.9.9.9", port=42381}
+1:main│ ├┐basic::server host="localhost", port=8080
+1:main│ │└┐basic::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ ├─ms DEBUG basic connected
 1:main│ │ ├─ms DEBUG basic message received, length=2
-1:main│ │┌┘basic::conn{peer_addr="82.9.9.9", port=42381}
-1:main│ ├┘basic::server{host="localhost", port=8080}
-1:main│ ├┐basic::server{host="localhost", port=8080}
-1:main│ │└┐basic::conn{peer_addr="8.8.8.8", port=18230}
+1:main│ │┌┘basic::conn peer_addr="82.9.9.9", port=42381
+1:main│ ├┘basic::server host="localhost", port=8080
+1:main│ ├┐basic::server host="localhost", port=8080
+1:main│ │└┐basic::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ ├─ms DEBUG basic connected
-1:main│ │┌┘basic::conn{peer_addr="8.8.8.8", port=18230}
-1:main│ ├┘basic::server{host="localhost", port=8080}
-1:main│ ├┐basic::server{host="localhost", port=8080}
-1:main│ │└┐basic::conn{peer_addr="82.9.9.9", port=42381}
+1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
+1:main│ ├┘basic::server host="localhost", port=8080
+1:main│ ├┐basic::server host="localhost", port=8080
+1:main│ │└┐basic::foomp 42 <- format string, normal_var=43
+1:main│ │ ├─ms ERROR basic hello
+1:main│ │┌┘basic::foomp 42 <- format string, normal_var=43
+1:main│ ├┘basic::server host="localhost", port=8080
+1:main│ ├┐basic::server host="localhost", port=8080
+1:main│ │└┐basic::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ ├─ms WARN basic weak encryption requested, algo="xor"
 1:main│ │ ├─ms DEBUG basic response sent, length=8
 1:main│ │ ├─ms DEBUG basic disconnected
-1:main│ │┌┘basic::conn{peer_addr="82.9.9.9", port=42381}
-1:main│ ├┘basic::server{host="localhost", port=8080}
-1:main│ ├┐basic::server{host="localhost", port=8080}
-1:main│ │└┐basic::conn{peer_addr="8.8.8.8", port=18230}
+1:main│ │┌┘basic::conn peer_addr="82.9.9.9", port=42381
+1:main│ ├┘basic::server host="localhost", port=8080
+1:main│ ├┐basic::server host="localhost", port=8080
+1:main│ │└┐basic::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ ├─ms DEBUG basic message received, length=5
 1:main│ │ ├─ms DEBUG basic response sent, length=8
 1:main│ │ ├─ms DEBUG basic disconnected
-1:main│ │┌┘basic::conn{peer_addr="8.8.8.8", port=18230}
-1:main│ ├┘basic::server{host="localhost", port=8080}
+1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
+1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├─ms WARN basic internal error
 1:main│ ├─ms INFO basic exit
-1:main│┌┘basic::server{host="localhost", port=8080}
-1:main├┘basic::hierarchical-example{version=0.1}
-1:mainbasic::hierarchical-example{version=0.1}
+1:main│┌┘basic::server host="localhost", port=8080
+1:main├┘basic::hierarchical-example version=0.1
+1:mainbasic::hierarchical-example version=0.1

--- a/examples/stderr.rs
+++ b/examples/stderr.rs
@@ -29,6 +29,7 @@ fn main() {
     let layer = HierarchicalLayer::default()
         .with_indent_lines(true)
         .with_indent_amount(2)
+        .with_bracketed_fields(true)
         .with_writer(std::io::stderr);
 
     let subscriber = Registry::default().with(layer);

--- a/examples/wraparound.stdout
+++ b/examples/wraparound.stdout
@@ -1,67 +1,67 @@
-1:mainwraparound::recurse{i=0}
+1:mainwraparound::recurse i=0
 1:main├─ms WARN wraparound boop
-1:main├┐wraparound::recurse{i=0}
-1:main│└┐wraparound::recurse{i=1}
+1:main├┐wraparound::recurse i=0
+1:main│└┐wraparound::recurse i=1
 1:main│ ├─ms WARN wraparound boop
-1:main│ ├┐wraparound::recurse{i=1}
-1:main│ │└┐wraparound::recurse{i=2}
+1:main│ ├┐wraparound::recurse i=1
+1:main│ │└┐wraparound::recurse i=2
 1:main│ │ ├─ms WARN wraparound boop
-1:main│ │ ├┐wraparound::recurse{i=2}
-1:main│ │ │└┐wraparound::recurse{i=3}
+1:main│ │ ├┐wraparound::recurse i=2
+1:main│ │ │└┐wraparound::recurse i=3
 1:main│ │ │ ├─ms WARN wraparound boop
-1:mainwraparound::recurse{i=3}
-1:mainwraparound::recurse{i=4}
+1:mainwraparound::recurse i=3
+1:mainwraparound::recurse i=4
 1:mainms WARN wraparound boop
-1:mainwraparound::recurse{i=4}
-1:mainwraparound::recurse{i=5}
+1:mainwraparound::recurse i=4
+1:mainwraparound::recurse i=5
 1:main├─ms WARN wraparound boop
-1:main├┐wraparound::recurse{i=5}
-1:main│└┐wraparound::recurse{i=6}
+1:main├┐wraparound::recurse i=5
+1:main│└┐wraparound::recurse i=6
 1:main│ ├─ms WARN wraparound boop
-1:main│ ├┐wraparound::recurse{i=6}
-1:main│ │└┐wraparound::recurse{i=7}
+1:main│ ├┐wraparound::recurse i=6
+1:main│ │└┐wraparound::recurse i=7
 1:main│ │ ├─ms WARN wraparound boop
-1:main│ │ ├┐wraparound::recurse{i=7}
-1:main│ │ │└┐wraparound::recurse{i=8}
+1:main│ │ ├┐wraparound::recurse i=7
+1:main│ │ │└┐wraparound::recurse i=8
 1:main│ │ │ ├─ms WARN wraparound boop
-1:mainwraparound::recurse{i=8}
-1:mainwraparound::recurse{i=9}
+1:mainwraparound::recurse i=8
+1:mainwraparound::recurse i=9
 1:mainms WARN wraparound boop
-1:mainwraparound::recurse{i=9}
-1:mainwraparound::recurse{i=10}
+1:mainwraparound::recurse i=9
+1:mainwraparound::recurse i=10
 1:main├─ms WARN wraparound boop
-1:main├┐wraparound::recurse{i=10}
-1:main│└┐wraparound::recurse{i=11}
+1:main├┐wraparound::recurse i=10
+1:main│└┐wraparound::recurse i=11
 1:main│ ├─ms WARN wraparound boop
-1:main│ ├┐wraparound::recurse{i=11}
-1:main│ │└┐wraparound::recurse{i=12}
+1:main│ ├┐wraparound::recurse i=11
+1:main│ │└┐wraparound::recurse i=12
 1:main│ │ ├─ms WARN wraparound boop
-1:main│ │ ├┐wraparound::recurse{i=12}
-1:main│ │ │└┐wraparound::recurse{i=13}
+1:main│ │ ├┐wraparound::recurse i=12
+1:main│ │ │└┐wraparound::recurse i=13
 1:main│ │ │ ├─ms WARN wraparound boop
-1:mainwraparound::recurse{i=13}
-1:mainwraparound::recurse{i=14}
+1:mainwraparound::recurse i=13
+1:mainwraparound::recurse i=14
 1:mainms WARN wraparound boop
-1:mainwraparound::recurse{i=14}
-1:mainwraparound::recurse{i=15}
+1:mainwraparound::recurse i=14
+1:mainwraparound::recurse i=15
 1:main├─ms WARN wraparound boop
-1:main├┐wraparound::recurse{i=15}
-1:main│└┐wraparound::recurse{i=16}
+1:main├┐wraparound::recurse i=15
+1:main│└┐wraparound::recurse i=16
 1:main│ ├─ms WARN wraparound boop
-1:main│ ├┐wraparound::recurse{i=16}
-1:main│ │└┐wraparound::recurse{i=17}
+1:main│ ├┐wraparound::recurse i=16
+1:main│ │└┐wraparound::recurse i=17
 1:main│ │ ├─ms WARN wraparound boop
-1:main│ │ ├┐wraparound::recurse{i=17}
-1:main│ │ │└┐wraparound::recurse{i=18}
+1:main│ │ ├┐wraparound::recurse i=17
+1:main│ │ │└┐wraparound::recurse i=18
 1:main│ │ │ ├─ms WARN wraparound boop
-1:mainwraparound::recurse{i=18}
-1:mainwraparound::recurse{i=19}
+1:mainwraparound::recurse i=18
+1:mainwraparound::recurse i=19
 1:mainms WARN wraparound boop
-1:mainwraparound::recurse{i=19}
-1:mainwraparound::recurse{i=20}
+1:mainwraparound::recurse i=19
+1:mainwraparound::recurse i=20
 1:main├─ms WARN wraparound boop
-1:main├┐wraparound::recurse{i=20}
-1:main│└┐wraparound::recurse{i=21}
+1:main├┐wraparound::recurse i=20
+1:main│└┐wraparound::recurse i=21
 1:main│ ├─ms WARN wraparound boop
 1:main│ ├─ms WARN wraparound bop
 1:main├─ms WARN wraparound bop

--- a/src/format.rs
+++ b/src/format.rs
@@ -42,6 +42,8 @@ pub struct Config {
     pub verbose_entry: bool,
     /// Whether to print the current span before exiting it.
     pub verbose_exit: bool,
+    /// Whether to print squiggly brackets (`{}`) around the list of fields in a span.
+    pub bracketed_fields: bool,
 }
 
 impl Config {
@@ -92,6 +94,13 @@ impl Config {
         }
     }
 
+    pub fn with_bracketed_fields(self, bracketed_fields: bool) -> Self {
+        Self {
+            bracketed_fields,
+            ..self
+        }
+    }
+
     pub(crate) fn prefix(&self) -> String {
         let mut buf = String::new();
         if self.render_thread_ids {
@@ -127,6 +136,7 @@ impl Default for Config {
             wraparound: usize::max_value(),
             verbose_entry: false,
             verbose_exit: false,
+            bracketed_fields: false,
         }
     }
 }


### PR DESCRIPTION
I found some other code that was also matching on the `message` name and skipped printing it. I extended it to the code here, but I was unable to figure out how the other code is invoked or how to trigger it, since it looks to me like it would render `"foo"` instead of `foo`, because it's using `Debug` printing which renders quotes around strings.

Here's a rendered version:

![Screenshot from 2020-08-18 18-29-33](https://user-images.githubusercontent.com/332036/90539998-dbec9580-e180-11ea-954c-882a4ee5ea1c.png)

As text:

```
1:main│ ├┐basic::server host="localhost", port=8080
1:main│ │└┐basic::foomp 42 <- format string, normal_var=43
1:main│ │ ├─0ms ERROR basic hello
1:main│ │┌┘basic::foomp 42 <- format string, normal_var=43
1:main│ ├┘basic::server host="localhost", port=8080
```

fixes #18 