### PR TITLE
UI testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,11 @@ termcolor = "1.0.5"
 ansi_term = "0.12.1"
 chrono = "0.4.10"
 atty = "0.2.14"
+
+[dev-dependencies]
+glob = "0.3.0"
+assert_cmd = "1.0.1"
+
+[[test]]
+name = "ui"
+harness = false

--- a/examples/basic.stdout
+++ b/examples/basic.stdout
@@ -1,35 +1,35 @@
 1:mainbasic::hierarchical-example{version=0.1}
 1:main├┐basic::hierarchical-example{version=0.1}
 1:main│└┐basic::server{host="localhost", port=8080}
-1:main│ ├─0ms INFO basic starting
-1:main│ ├─300ms INFO basic listening
+1:main│ ├─ms INFO basic starting
+1:main│ ├─ms INFO basic listening
 1:main│ ├┐basic::server{host="localhost", port=8080}
 1:main│ │└┐basic::conn{peer_addr="82.9.9.9", port=42381}
-1:main│ │ ├─0ms DEBUG basic connected
-1:main│ │ ├─300ms DEBUG basic message received, length=2
+1:main│ │ ├─ms DEBUG basic connected
+1:main│ │ ├─ms DEBUG basic message received, length=2
 1:main│ │┌┘basic::conn{peer_addr="82.9.9.9", port=42381}
 1:main│ ├┘basic::server{host="localhost", port=8080}
 1:main│ ├┐basic::server{host="localhost", port=8080}
 1:main│ │└┐basic::conn{peer_addr="8.8.8.8", port=18230}
-1:main│ │ ├─300ms DEBUG basic connected
+1:main│ │ ├─ms DEBUG basic connected
 1:main│ │┌┘basic::conn{peer_addr="8.8.8.8", port=18230}
 1:main│ ├┘basic::server{host="localhost", port=8080}
 1:main│ ├┐basic::server{host="localhost", port=8080}
 1:main│ │└┐basic::conn{peer_addr="82.9.9.9", port=42381}
-1:main│ │ ├─601ms WARN basic weak encryption requested, algo="xor"
-1:main│ │ ├─901ms DEBUG basic response sent, length=8
-1:main│ │ ├─901ms DEBUG basic disconnected
+1:main│ │ ├─ms WARN basic weak encryption requested, algo="xor"
+1:main│ │ ├─ms DEBUG basic response sent, length=8
+1:main│ │ ├─ms DEBUG basic disconnected
 1:main│ │┌┘basic::conn{peer_addr="82.9.9.9", port=42381}
 1:main│ ├┘basic::server{host="localhost", port=8080}
 1:main│ ├┐basic::server{host="localhost", port=8080}
 1:main│ │└┐basic::conn{peer_addr="8.8.8.8", port=18230}
-1:main│ │ ├─601ms DEBUG basic message received, length=5
-1:main│ │ ├─901ms DEBUG basic response sent, length=8
-1:main│ │ ├─901ms DEBUG basic disconnected
+1:main│ │ ├─ms DEBUG basic message received, length=5
+1:main│ │ ├─ms DEBUG basic response sent, length=8
+1:main│ │ ├─ms DEBUG basic disconnected
 1:main│ │┌┘basic::conn{peer_addr="8.8.8.8", port=18230}
 1:main│ ├┘basic::server{host="localhost", port=8080}
-1:main│ ├─1503ms WARN basic internal error
-1:main│ ├─1503ms INFO basic exit
+1:main│ ├─ms WARN basic internal error
+1:main│ ├─ms INFO basic exit
 1:main│┌┘basic::server{host="localhost", port=8080}
 1:main├┘basic::hierarchical-example{version=0.1}
 1:mainbasic::hierarchical-example{version=0.1}

--- a/examples/basic.stdout
+++ b/examples/basic.stdout
@@ -1,0 +1,35 @@
+1:mainbasic::hierarchical-example{version=0.1}
+1:main├┐basic::hierarchical-example{version=0.1}
+1:main│└┐basic::server{host="localhost", port=8080}
+1:main│ ├─0ms INFO basic starting
+1:main│ ├─300ms INFO basic listening
+1:main│ ├┐basic::server{host="localhost", port=8080}
+1:main│ │└┐basic::conn{peer_addr="82.9.9.9", port=42381}
+1:main│ │ ├─0ms DEBUG basic connected
+1:main│ │ ├─300ms DEBUG basic message received, length=2
+1:main│ │┌┘basic::conn{peer_addr="82.9.9.9", port=42381}
+1:main│ ├┘basic::server{host="localhost", port=8080}
+1:main│ ├┐basic::server{host="localhost", port=8080}
+1:main│ │└┐basic::conn{peer_addr="8.8.8.8", port=18230}
+1:main│ │ ├─300ms DEBUG basic connected
+1:main│ │┌┘basic::conn{peer_addr="8.8.8.8", port=18230}
+1:main│ ├┘basic::server{host="localhost", port=8080}
+1:main│ ├┐basic::server{host="localhost", port=8080}
+1:main│ │└┐basic::conn{peer_addr="82.9.9.9", port=42381}
+1:main│ │ ├─601ms WARN basic weak encryption requested, algo="xor"
+1:main│ │ ├─901ms DEBUG basic response sent, length=8
+1:main│ │ ├─901ms DEBUG basic disconnected
+1:main│ │┌┘basic::conn{peer_addr="82.9.9.9", port=42381}
+1:main│ ├┘basic::server{host="localhost", port=8080}
+1:main│ ├┐basic::server{host="localhost", port=8080}
+1:main│ │└┐basic::conn{peer_addr="8.8.8.8", port=18230}
+1:main│ │ ├─601ms DEBUG basic message received, length=5
+1:main│ │ ├─901ms DEBUG basic response sent, length=8
+1:main│ │ ├─901ms DEBUG basic disconnected
+1:main│ │┌┘basic::conn{peer_addr="8.8.8.8", port=18230}
+1:main│ ├┘basic::server{host="localhost", port=8080}
+1:main│ ├─1503ms WARN basic internal error
+1:main│ ├─1503ms INFO basic exit
+1:main│┌┘basic::server{host="localhost", port=8080}
+1:main├┘basic::hierarchical-example{version=0.1}
+1:mainbasic::hierarchical-example{version=0.1}

--- a/examples/stderr.stderr
+++ b/examples/stderr.stderr
@@ -1,110 +1,110 @@
 fibonacci_seq{to=5}
-├─0ms DEBUG Pushing 0 fibonacci
+├─ms DEBUG Pushing 0 fibonacci
 ├┐fibonacci_seq{to=5}
 │└┐nth_fibonacci{n=0}
-│ ├─0ms DEBUG Base case
-├─0ms DEBUG Pushing 1 fibonacci
+│ ├─ms DEBUG Base case
+├─ms DEBUG Pushing 1 fibonacci
 ├┐fibonacci_seq{to=5}
 │└┐nth_fibonacci{n=1}
-│ ├─0ms DEBUG Base case
-├─0ms DEBUG Pushing 2 fibonacci
+│ ├─ms DEBUG Base case
+├─ms DEBUG Pushing 2 fibonacci
 ├┐fibonacci_seq{to=5}
 │└┐nth_fibonacci{n=2}
-│ ├─0ms DEBUG Recursing
+│ ├─ms DEBUG Recursing
 │ ├┐nth_fibonacci{n=2}
 │ │└┐nth_fibonacci{n=1}
-│ │ ├─0ms DEBUG Base case
+│ │ ├─ms DEBUG Base case
 │ ├┐nth_fibonacci{n=2}
 │ │└┐nth_fibonacci{n=0}
-│ │ ├─0ms DEBUG Base case
-├─1ms DEBUG Pushing 3 fibonacci
+│ │ ├─ms DEBUG Base case
+├─ms DEBUG Pushing 3 fibonacci
 ├┐fibonacci_seq{to=5}
 │└┐nth_fibonacci{n=3}
-│ ├─0ms DEBUG Recursing
+│ ├─ms DEBUG Recursing
 │ ├┐nth_fibonacci{n=3}
 │ │└┐nth_fibonacci{n=2}
-│ │ ├─0ms DEBUG Recursing
+│ │ ├─ms DEBUG Recursing
 │ │ ├┐nth_fibonacci{n=2}
 │ │ │└┐nth_fibonacci{n=1}
-│ │ │ ├─0ms DEBUG Base case
+│ │ │ ├─ms DEBUG Base case
 │ │ ├┐nth_fibonacci{n=2}
 │ │ │└┐nth_fibonacci{n=0}
-│ │ │ ├─0ms DEBUG Base case
+│ │ │ ├─ms DEBUG Base case
 │ ├┐nth_fibonacci{n=3}
 │ │└┐nth_fibonacci{n=1}
-│ │ ├─0ms DEBUG Base case
-├─2ms DEBUG Pushing 4 fibonacci
+│ │ ├─ms DEBUG Base case
+├─ms DEBUG Pushing 4 fibonacci
 ├┐fibonacci_seq{to=5}
 │└┐nth_fibonacci{n=4}
-│ ├─0ms DEBUG Recursing
+│ ├─ms DEBUG Recursing
 │ ├┐nth_fibonacci{n=4}
 │ │└┐nth_fibonacci{n=3}
-│ │ ├─0ms DEBUG Recursing
+│ │ ├─ms DEBUG Recursing
 │ │ ├┐nth_fibonacci{n=3}
 │ │ │└┐nth_fibonacci{n=2}
-│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├─ms DEBUG Recursing
 │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │└┐nth_fibonacci{n=1}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │└┐nth_fibonacci{n=0}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ │ ├┐nth_fibonacci{n=3}
 │ │ │└┐nth_fibonacci{n=1}
-│ │ │ ├─0ms DEBUG Base case
+│ │ │ ├─ms DEBUG Base case
 │ ├┐nth_fibonacci{n=4}
 │ │└┐nth_fibonacci{n=2}
-│ │ ├─0ms DEBUG Recursing
+│ │ ├─ms DEBUG Recursing
 │ │ ├┐nth_fibonacci{n=2}
 │ │ │└┐nth_fibonacci{n=1}
-│ │ │ ├─0ms DEBUG Base case
+│ │ │ ├─ms DEBUG Base case
 │ │ ├┐nth_fibonacci{n=2}
 │ │ │└┐nth_fibonacci{n=0}
-│ │ │ ├─0ms DEBUG Base case
-├─4ms DEBUG Pushing 5 fibonacci
+│ │ │ ├─ms DEBUG Base case
+├─ms DEBUG Pushing 5 fibonacci
 ├┐fibonacci_seq{to=5}
 │└┐nth_fibonacci{n=5}
-│ ├─0ms DEBUG Recursing
+│ ├─ms DEBUG Recursing
 │ ├┐nth_fibonacci{n=5}
 │ │└┐nth_fibonacci{n=4}
-│ │ ├─0ms DEBUG Recursing
+│ │ ├─ms DEBUG Recursing
 │ │ ├┐nth_fibonacci{n=4}
 │ │ │└┐nth_fibonacci{n=3}
-│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├─ms DEBUG Recursing
 │ │ │ ├┐nth_fibonacci{n=3}
 │ │ │ │└┐nth_fibonacci{n=2}
-│ │ │ │ ├─0ms DEBUG Recursing
+│ │ │ │ ├─ms DEBUG Recursing
 │ │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │ │└┐nth_fibonacci{n=1}
-│ │ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ │ ├─ms DEBUG Base case
 │ │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │ │└┐nth_fibonacci{n=0}
-│ │ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ │ ├─ms DEBUG Base case
 │ │ │ ├┐nth_fibonacci{n=3}
 │ │ │ │└┐nth_fibonacci{n=1}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ │ ├┐nth_fibonacci{n=4}
 │ │ │└┐nth_fibonacci{n=2}
-│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├─ms DEBUG Recursing
 │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │└┐nth_fibonacci{n=1}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │└┐nth_fibonacci{n=0}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ ├┐nth_fibonacci{n=5}
 │ │└┐nth_fibonacci{n=3}
-│ │ ├─0ms DEBUG Recursing
+│ │ ├─ms DEBUG Recursing
 │ │ ├┐nth_fibonacci{n=3}
 │ │ │└┐nth_fibonacci{n=2}
-│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├─ms DEBUG Recursing
 │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │└┐nth_fibonacci{n=1}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ │ │ ├┐nth_fibonacci{n=2}
 │ │ │ │└┐nth_fibonacci{n=0}
-│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├─ms DEBUG Base case
 │ │ ├┐nth_fibonacci{n=3}
 │ │ │└┐nth_fibonacci{n=1}
-│ │ │ ├─0ms DEBUG Base case
+│ │ │ ├─ms DEBUG Base case
 INFO The first 5 fibonacci numbers are [1, 1, 2, 3, 5, 8]

--- a/examples/stderr.stderr
+++ b/examples/stderr.stderr
@@ -1,0 +1,110 @@
+fibonacci_seq{to=5}
+├─0ms DEBUG Pushing 0 fibonacci
+├┐fibonacci_seq{to=5}
+│└┐nth_fibonacci{n=0}
+│ ├─0ms DEBUG Base case
+├─0ms DEBUG Pushing 1 fibonacci
+├┐fibonacci_seq{to=5}
+│└┐nth_fibonacci{n=1}
+│ ├─0ms DEBUG Base case
+├─0ms DEBUG Pushing 2 fibonacci
+├┐fibonacci_seq{to=5}
+│└┐nth_fibonacci{n=2}
+│ ├─0ms DEBUG Recursing
+│ ├┐nth_fibonacci{n=2}
+│ │└┐nth_fibonacci{n=1}
+│ │ ├─0ms DEBUG Base case
+│ ├┐nth_fibonacci{n=2}
+│ │└┐nth_fibonacci{n=0}
+│ │ ├─0ms DEBUG Base case
+├─1ms DEBUG Pushing 3 fibonacci
+├┐fibonacci_seq{to=5}
+│└┐nth_fibonacci{n=3}
+│ ├─0ms DEBUG Recursing
+│ ├┐nth_fibonacci{n=3}
+│ │└┐nth_fibonacci{n=2}
+│ │ ├─0ms DEBUG Recursing
+│ │ ├┐nth_fibonacci{n=2}
+│ │ │└┐nth_fibonacci{n=1}
+│ │ │ ├─0ms DEBUG Base case
+│ │ ├┐nth_fibonacci{n=2}
+│ │ │└┐nth_fibonacci{n=0}
+│ │ │ ├─0ms DEBUG Base case
+│ ├┐nth_fibonacci{n=3}
+│ │└┐nth_fibonacci{n=1}
+│ │ ├─0ms DEBUG Base case
+├─2ms DEBUG Pushing 4 fibonacci
+├┐fibonacci_seq{to=5}
+│└┐nth_fibonacci{n=4}
+│ ├─0ms DEBUG Recursing
+│ ├┐nth_fibonacci{n=4}
+│ │└┐nth_fibonacci{n=3}
+│ │ ├─0ms DEBUG Recursing
+│ │ ├┐nth_fibonacci{n=3}
+│ │ │└┐nth_fibonacci{n=2}
+│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │└┐nth_fibonacci{n=1}
+│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │└┐nth_fibonacci{n=0}
+│ │ │ │ ├─0ms DEBUG Base case
+│ │ ├┐nth_fibonacci{n=3}
+│ │ │└┐nth_fibonacci{n=1}
+│ │ │ ├─0ms DEBUG Base case
+│ ├┐nth_fibonacci{n=4}
+│ │└┐nth_fibonacci{n=2}
+│ │ ├─0ms DEBUG Recursing
+│ │ ├┐nth_fibonacci{n=2}
+│ │ │└┐nth_fibonacci{n=1}
+│ │ │ ├─0ms DEBUG Base case
+│ │ ├┐nth_fibonacci{n=2}
+│ │ │└┐nth_fibonacci{n=0}
+│ │ │ ├─0ms DEBUG Base case
+├─4ms DEBUG Pushing 5 fibonacci
+├┐fibonacci_seq{to=5}
+│└┐nth_fibonacci{n=5}
+│ ├─0ms DEBUG Recursing
+│ ├┐nth_fibonacci{n=5}
+│ │└┐nth_fibonacci{n=4}
+│ │ ├─0ms DEBUG Recursing
+│ │ ├┐nth_fibonacci{n=4}
+│ │ │└┐nth_fibonacci{n=3}
+│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├┐nth_fibonacci{n=3}
+│ │ │ │└┐nth_fibonacci{n=2}
+│ │ │ │ ├─0ms DEBUG Recursing
+│ │ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │ │└┐nth_fibonacci{n=1}
+│ │ │ │ │ ├─0ms DEBUG Base case
+│ │ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │ │└┐nth_fibonacci{n=0}
+│ │ │ │ │ ├─0ms DEBUG Base case
+│ │ │ ├┐nth_fibonacci{n=3}
+│ │ │ │└┐nth_fibonacci{n=1}
+│ │ │ │ ├─0ms DEBUG Base case
+│ │ ├┐nth_fibonacci{n=4}
+│ │ │└┐nth_fibonacci{n=2}
+│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │└┐nth_fibonacci{n=1}
+│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │└┐nth_fibonacci{n=0}
+│ │ │ │ ├─0ms DEBUG Base case
+│ ├┐nth_fibonacci{n=5}
+│ │└┐nth_fibonacci{n=3}
+│ │ ├─0ms DEBUG Recursing
+│ │ ├┐nth_fibonacci{n=3}
+│ │ │└┐nth_fibonacci{n=2}
+│ │ │ ├─0ms DEBUG Recursing
+│ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │└┐nth_fibonacci{n=1}
+│ │ │ │ ├─0ms DEBUG Base case
+│ │ │ ├┐nth_fibonacci{n=2}
+│ │ │ │└┐nth_fibonacci{n=0}
+│ │ │ │ ├─0ms DEBUG Base case
+│ │ ├┐nth_fibonacci{n=3}
+│ │ │└┐nth_fibonacci{n=1}
+│ │ │ ├─0ms DEBUG Base case
+INFO The first 5 fibonacci numbers are [1, 1, 2, 3, 5, 8]

--- a/examples/wraparound.stdout
+++ b/examples/wraparound.stdout
@@ -1,0 +1,87 @@
+1:mainwraparound::recurse{i=0}
+1:main├─0ms WARN wraparound boop
+1:main├┐wraparound::recurse{i=0}
+1:main│└┐wraparound::recurse{i=1}
+1:main│ ├─0ms WARN wraparound boop
+1:main│ ├┐wraparound::recurse{i=1}
+1:main│ │└┐wraparound::recurse{i=2}
+1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├┐wraparound::recurse{i=2}
+1:main│ │ │└┐wraparound::recurse{i=3}
+1:main│ │ │ ├─0ms WARN wraparound boop
+1:mainwraparound::recurse{i=3}
+1:mainwraparound::recurse{i=4}
+1:main0ms WARN wraparound boop
+1:mainwraparound::recurse{i=4}
+1:mainwraparound::recurse{i=5}
+1:main├─0ms WARN wraparound boop
+1:main├┐wraparound::recurse{i=5}
+1:main│└┐wraparound::recurse{i=6}
+1:main│ ├─0ms WARN wraparound boop
+1:main│ ├┐wraparound::recurse{i=6}
+1:main│ │└┐wraparound::recurse{i=7}
+1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├┐wraparound::recurse{i=7}
+1:main│ │ │└┐wraparound::recurse{i=8}
+1:main│ │ │ ├─0ms WARN wraparound boop
+1:mainwraparound::recurse{i=8}
+1:mainwraparound::recurse{i=9}
+1:main0ms WARN wraparound boop
+1:mainwraparound::recurse{i=9}
+1:mainwraparound::recurse{i=10}
+1:main├─0ms WARN wraparound boop
+1:main├┐wraparound::recurse{i=10}
+1:main│└┐wraparound::recurse{i=11}
+1:main│ ├─0ms WARN wraparound boop
+1:main│ ├┐wraparound::recurse{i=11}
+1:main│ │└┐wraparound::recurse{i=12}
+1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├┐wraparound::recurse{i=12}
+1:main│ │ │└┐wraparound::recurse{i=13}
+1:main│ │ │ ├─0ms WARN wraparound boop
+1:mainwraparound::recurse{i=13}
+1:mainwraparound::recurse{i=14}
+1:main0ms WARN wraparound boop
+1:mainwraparound::recurse{i=14}
+1:mainwraparound::recurse{i=15}
+1:main├─0ms WARN wraparound boop
+1:main├┐wraparound::recurse{i=15}
+1:main│└┐wraparound::recurse{i=16}
+1:main│ ├─0ms WARN wraparound boop
+1:main│ ├┐wraparound::recurse{i=16}
+1:main│ │└┐wraparound::recurse{i=17}
+1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├┐wraparound::recurse{i=17}
+1:main│ │ │└┐wraparound::recurse{i=18}
+1:main│ │ │ ├─0ms WARN wraparound boop
+1:mainwraparound::recurse{i=18}
+1:mainwraparound::recurse{i=19}
+1:main0ms WARN wraparound boop
+1:mainwraparound::recurse{i=19}
+1:mainwraparound::recurse{i=20}
+1:main├─0ms WARN wraparound boop
+1:main├┐wraparound::recurse{i=20}
+1:main│└┐wraparound::recurse{i=21}
+1:main│ ├─0ms WARN wraparound boop
+1:main│ ├─0ms WARN wraparound bop
+1:main├─1ms WARN wraparound bop
+1:main2ms WARN wraparound bop
+1:main│ │ │ ├─2ms WARN wraparound bop
+1:main│ │ ├─3ms WARN wraparound bop
+1:main│ ├─4ms WARN wraparound bop
+1:main├─4ms WARN wraparound bop
+1:main5ms WARN wraparound bop
+1:main│ │ │ ├─6ms WARN wraparound bop
+1:main│ │ ├─6ms WARN wraparound bop
+1:main│ ├─7ms WARN wraparound bop
+1:main├─7ms WARN wraparound bop
+1:main7ms WARN wraparound bop
+1:main│ │ │ ├─8ms WARN wraparound bop
+1:main│ │ ├─8ms WARN wraparound bop
+1:main│ ├─9ms WARN wraparound bop
+1:main├─9ms WARN wraparound bop
+1:main9ms WARN wraparound bop
+1:main│ │ │ ├─10ms WARN wraparound bop
+1:main│ │ ├─10ms WARN wraparound bop
+1:main│ ├─10ms WARN wraparound bop
+1:main├─11ms WARN wraparound bop

--- a/examples/wraparound.stdout
+++ b/examples/wraparound.stdout
@@ -1,87 +1,87 @@
 1:mainwraparound::recurse{i=0}
-1:main├─0ms WARN wraparound boop
+1:main├─ms WARN wraparound boop
 1:main├┐wraparound::recurse{i=0}
 1:main│└┐wraparound::recurse{i=1}
-1:main│ ├─0ms WARN wraparound boop
+1:main│ ├─ms WARN wraparound boop
 1:main│ ├┐wraparound::recurse{i=1}
 1:main│ │└┐wraparound::recurse{i=2}
-1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├─ms WARN wraparound boop
 1:main│ │ ├┐wraparound::recurse{i=2}
 1:main│ │ │└┐wraparound::recurse{i=3}
-1:main│ │ │ ├─0ms WARN wraparound boop
+1:main│ │ │ ├─ms WARN wraparound boop
 1:mainwraparound::recurse{i=3}
 1:mainwraparound::recurse{i=4}
-1:main0ms WARN wraparound boop
+1:mainms WARN wraparound boop
 1:mainwraparound::recurse{i=4}
 1:mainwraparound::recurse{i=5}
-1:main├─0ms WARN wraparound boop
+1:main├─ms WARN wraparound boop
 1:main├┐wraparound::recurse{i=5}
 1:main│└┐wraparound::recurse{i=6}
-1:main│ ├─0ms WARN wraparound boop
+1:main│ ├─ms WARN wraparound boop
 1:main│ ├┐wraparound::recurse{i=6}
 1:main│ │└┐wraparound::recurse{i=7}
-1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├─ms WARN wraparound boop
 1:main│ │ ├┐wraparound::recurse{i=7}
 1:main│ │ │└┐wraparound::recurse{i=8}
-1:main│ │ │ ├─0ms WARN wraparound boop
+1:main│ │ │ ├─ms WARN wraparound boop
 1:mainwraparound::recurse{i=8}
 1:mainwraparound::recurse{i=9}
-1:main0ms WARN wraparound boop
+1:mainms WARN wraparound boop
 1:mainwraparound::recurse{i=9}
 1:mainwraparound::recurse{i=10}
-1:main├─0ms WARN wraparound boop
+1:main├─ms WARN wraparound boop
 1:main├┐wraparound::recurse{i=10}
 1:main│└┐wraparound::recurse{i=11}
-1:main│ ├─0ms WARN wraparound boop
+1:main│ ├─ms WARN wraparound boop
 1:main│ ├┐wraparound::recurse{i=11}
 1:main│ │└┐wraparound::recurse{i=12}
-1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├─ms WARN wraparound boop
 1:main│ │ ├┐wraparound::recurse{i=12}
 1:main│ │ │└┐wraparound::recurse{i=13}
-1:main│ │ │ ├─0ms WARN wraparound boop
+1:main│ │ │ ├─ms WARN wraparound boop
 1:mainwraparound::recurse{i=13}
 1:mainwraparound::recurse{i=14}
-1:main0ms WARN wraparound boop
+1:mainms WARN wraparound boop
 1:mainwraparound::recurse{i=14}
 1:mainwraparound::recurse{i=15}
-1:main├─0ms WARN wraparound boop
+1:main├─ms WARN wraparound boop
 1:main├┐wraparound::recurse{i=15}
 1:main│└┐wraparound::recurse{i=16}
-1:main│ ├─0ms WARN wraparound boop
+1:main│ ├─ms WARN wraparound boop
 1:main│ ├┐wraparound::recurse{i=16}
 1:main│ │└┐wraparound::recurse{i=17}
-1:main│ │ ├─0ms WARN wraparound boop
+1:main│ │ ├─ms WARN wraparound boop
 1:main│ │ ├┐wraparound::recurse{i=17}
 1:main│ │ │└┐wraparound::recurse{i=18}
-1:main│ │ │ ├─0ms WARN wraparound boop
+1:main│ │ │ ├─ms WARN wraparound boop
 1:mainwraparound::recurse{i=18}
 1:mainwraparound::recurse{i=19}
-1:main0ms WARN wraparound boop
+1:mainms WARN wraparound boop
 1:mainwraparound::recurse{i=19}
 1:mainwraparound::recurse{i=20}
-1:main├─0ms WARN wraparound boop
+1:main├─ms WARN wraparound boop
 1:main├┐wraparound::recurse{i=20}
 1:main│└┐wraparound::recurse{i=21}
-1:main│ ├─0ms WARN wraparound boop
-1:main│ ├─0ms WARN wraparound bop
-1:main├─1ms WARN wraparound bop
-1:main2ms WARN wraparound bop
-1:main│ │ │ ├─2ms WARN wraparound bop
-1:main│ │ ├─3ms WARN wraparound bop
-1:main│ ├─4ms WARN wraparound bop
-1:main├─4ms WARN wraparound bop
-1:main5ms WARN wraparound bop
-1:main│ │ │ ├─6ms WARN wraparound bop
-1:main│ │ ├─6ms WARN wraparound bop
-1:main│ ├─7ms WARN wraparound bop
-1:main├─7ms WARN wraparound bop
-1:main7ms WARN wraparound bop
-1:main│ │ │ ├─8ms WARN wraparound bop
-1:main│ │ ├─8ms WARN wraparound bop
-1:main│ ├─9ms WARN wraparound bop
-1:main├─9ms WARN wraparound bop
-1:main9ms WARN wraparound bop
-1:main│ │ │ ├─10ms WARN wraparound bop
-1:main│ │ ├─10ms WARN wraparound bop
-1:main│ ├─10ms WARN wraparound bop
-1:main├─11ms WARN wraparound bop
+1:main│ ├─ms WARN wraparound boop
+1:main│ ├─ms WARN wraparound bop
+1:main├─ms WARN wraparound bop
+1:mainms WARN wraparound bop
+1:main│ │ │ ├─ms WARN wraparound bop
+1:main│ │ ├─ms WARN wraparound bop
+1:main│ ├─ms WARN wraparound bop
+1:main├─ms WARN wraparound bop
+1:mainms WARN wraparound bop
+1:main│ │ │ ├─ms WARN wraparound bop
+1:main│ │ ├─ms WARN wraparound bop
+1:main│ ├─ms WARN wraparound bop
+1:main├─ms WARN wraparound bop
+1:mainms WARN wraparound bop
+1:main│ │ │ ├─ms WARN wraparound bop
+1:main│ │ ├─ms WARN wraparound bop
+1:main│ ├─ms WARN wraparound bop
+1:main├─ms WARN wraparound bop
+1:mainms WARN wraparound bop
+1:main│ │ │ ├─ms WARN wraparound bop
+1:main│ │ ├─ms WARN wraparound bop
+1:main│ ├─ms WARN wraparound bop
+1:main├─ms WARN wraparound bop

--- a/src/format.rs
+++ b/src/format.rs
@@ -215,8 +215,8 @@ fn indent_block_with_lines(
     style: SpanMode,
 ) {
     let indent = match style {
-        SpanMode::PreOpen => indent - 1,
-        SpanMode::Open => indent - 1,
+        SpanMode::PreOpen => indent.saturating_sub(1),
+        SpanMode::Open => indent.saturating_sub(1),
         SpanMode::Close => indent,
         SpanMode::PostClose => indent,
         SpanMode::Event => indent,

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -2,21 +2,78 @@ use assert_cmd::prelude::*;
 
 use std::process::Command;
 
+// Timings are flaky, so tests would spuriously fail.
+// Thus we replace all `/([0-9]+)ms/` with underscores
+fn replace_ms(data: &[u8]) -> Vec<u8> {
+    let mut skip = false;
+    let mut seen_s = false;
+    let mut v: Vec<u8> = data
+        .iter()
+        .rev()
+        .filter_map(|&b| match (b, skip, seen_s) {
+            (b'0'..=b'9', true, _) => None,
+            (_, true, _) => {
+                skip = false;
+                Some(b)
+            }
+            (b's', _, _) => {
+                seen_s = true;
+                Some(b)
+            }
+            (b'm', _, true) => {
+                seen_s = false;
+                skip = true;
+                Some(b)
+            }
+            _ => Some(b),
+        })
+        .collect();
+    v.reverse();
+    v
+}
+
 fn main() {
     for entry in glob::glob("examples/*.rs").expect("Failed to read glob pattern") {
         let entry = entry.unwrap();
-        let mut cmd = Command::cargo_bin(entry.with_extension("").to_str().unwrap())
-            .unwrap();
+        let mut cmd = Command::cargo_bin(entry.with_extension("").to_str().unwrap()).unwrap();
         let output = cmd.unwrap();
-        if output.stderr.is_empty() {
-            let _ = std::fs::remove_file(entry.with_extension("stderr"));
+        let stderr = entry.with_extension("stderr");
+        let stdout = entry.with_extension("stdout");
+
+        if std::env::args().any(|arg| arg == "--bless") {
+            if output.stderr.is_empty() {
+                let _ = std::fs::remove_file(stderr);
+            } else {
+                std::fs::write(stderr, replace_ms(&output.stderr)).unwrap();
+            }
+            if output.stdout.is_empty() {
+                let _ = std::fs::remove_file(stdout);
+            } else {
+                std::fs::write(stdout, replace_ms(&output.stdout)).unwrap();
+            }
         } else {
-            std::fs::write(entry.with_extension("stderr"), output.stderr).unwrap();
-        }
-        if output.stdout.is_empty() {
-            let _ = std::fs::remove_file(entry.with_extension("stdout"));
-        } else {
-            std::fs::write(entry.with_extension("stdout"), output.stdout).unwrap();
+            if output.stderr.is_empty() {
+                assert!(
+                    !stderr.exists(),
+                    "{} exists but there was no stderr output",
+                    stderr.display()
+                );
+            } else {
+                assert!(
+                    std::fs::read(&stderr).unwrap() == replace_ms(&output.stderr),
+                    "{} is not the expected output, rerun the test with `cargo test -- -- --bless`",
+                    stderr.display()
+                );
+            }
+            if output.stdout.is_empty() {
+                assert!(!stdout.exists());
+            } else {
+                assert!(
+                    std::fs::read(&stdout).unwrap() == replace_ms(&output.stdout),
+                    "{} is not the expected output, rerun the test with `cargo test -- -- --bless`",
+                    stdout.display()
+                );
+            }
         }
     }
 }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,22 @@
+use assert_cmd::prelude::*;
+
+use std::process::Command;
+
+fn main() {
+    for entry in glob::glob("examples/*.rs").expect("Failed to read glob pattern") {
+        let entry = entry.unwrap();
+        let mut cmd = Command::cargo_bin(entry.with_extension("").to_str().unwrap())
+            .unwrap();
+        let output = cmd.unwrap();
+        if output.stderr.is_empty() {
+            let _ = std::fs::remove_file(entry.with_extension("stderr"));
+        } else {
+            std::fs::write(entry.with_extension("stderr"), output.stderr).unwrap();
+        }
+        if output.stdout.is_empty() {
+            let _ = std::fs::remove_file(entry.with_extension("stdout"));
+        } else {
+            std::fs::write(entry.with_extension("stdout"), output.stdout).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
fixes #20 

I tried out compiletest-rs. Even though I set it up for clippy a few years back, I was unable to set it up here. I followed the instructions for finding dependencies, but nothing helped the ui tests to find the `tracing_subscriber` dependency. Additionally I got arbitrary rebuilds of all dependencies after tests ran and errored. This seemed very fragile and sub-optimal.

So, I wrote a quick script that makes `cargo test` check the `.stderr` files next to the examples on whether their output is the expected output. I can pull this into a separate crate if you prefer.