### PR TITLE
tracing-log emits excessive metadata fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,15 @@ termcolor = "1.0.5"
 ansi_term = "0.12.1"
 chrono = "0.4.10"
 atty = "0.2.14"
+tracing-log = { version = "0.1", optional = true }
+
+[features]
+default = ["tracing-log"]
 
 [dev-dependencies]
 glob = "0.3.0"
 assert_cmd = "1.0.1"
+log = "0.4.11"
 
 [[test]]
 name = "ui"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -14,6 +14,8 @@ fn main() {
 
     let subscriber = Registry::default().with(layer);
     tracing::subscriber::set_global_default(subscriber).unwrap();
+    #[cfg(feature = "tracing-log")]
+    tracing_log::LogTracer::init().unwrap();
 
     let app_span = span!(Level::TRACE, "hierarchical-example", version = %0.1);
     let _e = app_span.enter();
@@ -57,6 +59,7 @@ fn main() {
         debug!("disconnected");
     });
     warn!("internal error");
+    log::error!("this is a log message");
     info!("exit");
 }
 

--- a/examples/basic.stdout
+++ b/examples/basic.stdout
@@ -34,7 +34,7 @@
 1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
 1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├─ms WARN basic internal error
-1:main│ ├─ms ERROR log this is a log message, log.target="basic", log.module_path="basic", log.file="examples/basic.rs", log.line=63
+1:main│ ├─ms ERROR basic this is a log message
 1:main│ ├─ms INFO basic exit
 1:main│┌┘basic::server host="localhost", port=8080
 1:main├┘basic::hierarchical-example version=0.1

--- a/examples/basic.stdout
+++ b/examples/basic.stdout
@@ -34,6 +34,7 @@
 1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
 1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├─ms WARN basic internal error
+1:main│ ├─ms ERROR log this is a log message, log.target="basic", log.module_path="basic", log.file="examples/basic.rs", log.line=63
 1:main│ ├─ms INFO basic exit
 1:main│┌┘basic::server host="localhost", port=8080
 1:main├┘basic::hierarchical-example version=0.1


### PR DESCRIPTION
`tracing-log` needs some hacks to work, and I ported those hacks from `tracing-subscriber` to this repo. I now also understand `tracing-subscriber` a bit better, so I'll try to give it another try and reuse the formatter from `tracing-subscriber`

This PR is best reviewed commit by commit