### PR TITLE
chore: default to `stderr` as default output.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -4,6 +4,7 @@ use tracing_tree::HierarchicalLayer;
 
 fn main() {
     let layer = HierarchicalLayer::default()
+        .with_writer(std::io::stdout)
         .with_indent_lines(true)
         .with_indent_amount(2)
         .with_thread_names(true)

--- a/examples/quiet.rs
+++ b/examples/quiet.rs
@@ -4,6 +4,7 @@ use tracing_tree::HierarchicalLayer;
 
 fn main() {
     let layer = HierarchicalLayer::default()
+        .with_writer(std::io::stdout)
         .with_indent_lines(true)
         .with_indent_amount(2)
         .with_thread_names(true)

--- a/examples/stderr.rs
+++ b/examples/stderr.rs
@@ -29,8 +29,7 @@ fn main() {
     let layer = HierarchicalLayer::default()
         .with_indent_lines(true)
         .with_indent_amount(2)
-        .with_bracketed_fields(true)
-        .with_writer(std::io::stderr);
+        .with_bracketed_fields(true);
 
     let subscriber = Registry::default().with(layer);
     tracing::subscriber::set_global_default(subscriber).unwrap();

--- a/examples/wraparound.rs
+++ b/examples/wraparound.rs
@@ -4,6 +4,7 @@ use tracing_tree::HierarchicalLayer;
 
 fn main() {
     let layer = HierarchicalLayer::default()
+        .with_writer(std::io::stdout)
         .with_indent_lines(true)
         .with_indent_amount(2)
         .with_thread_names(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ impl Visit for Data {
 }
 
 #[derive(Debug)]
-pub struct HierarchicalLayer<W = fn() -> io::Stdout>
+pub struct HierarchicalLayer<W = fn() -> io::Stderr>
 where
     W: for<'writer> MakeWriter<'writer> + 'static,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,16 +59,16 @@ impl Default for HierarchicalLayer {
     }
 }
 
-impl HierarchicalLayer<fn() -> io::Stdout> {
+impl HierarchicalLayer<fn() -> io::Stderr> {
     pub fn new(indent_amount: usize) -> Self {
-        let ansi = atty::is(atty::Stream::Stdout);
+        let ansi = atty::is(atty::Stream::Stderr);
         let config = Config {
             ansi,
             indent_amount,
             ..Default::default()
         };
         Self {
-            make_writer: io::stdout,
+            make_writer: io::stderr,
             bufs: Mutex::new(Buffers::new()),
             config,
         }


### PR DESCRIPTION
Resolves #28.