### PR TITLE
chore: prepare tracing-tree 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-tree"
-version = "0.1.11"
+version = "0.2.0"
 authors = ["David Barsky <me@davidbarsky.com>", "Nathan Whitaker"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumping tracing-tree 0.2 due to the upgrade to tracing-subscriber 0.3 and defaulting to stderr for writing logs.