### PR TITLE
Replace unmaintained `ansi_term` crate with `nu_ansi_term` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "fmt", "std"] }
-ansi_term = "0.12"
+nu-ansi-term = "0.46.0"
 atty = "0.2"
 tracing-log = { version = "0.1", optional = true }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,4 +1,4 @@
-use ansi_term::Color;
+use nu_ansi_term::Color;
 use std::{
     fmt::{self, Write as _},
     io,
@@ -251,7 +251,7 @@ impl<'a> fmt::Display for ColorLevel<'a> {
             Level::TRACE => Color::Purple.bold().paint("TRACE"),
             Level::DEBUG => Color::Blue.bold().paint("DEBUG"),
             Level::INFO => Color::Green.bold().paint(" INFO"),
-            Level::WARN => Color::RGB(252, 234, 160).bold().paint(" WARN"), // orange
+            Level::WARN => Color::Rgb(252, 234, 160).bold().paint(" WARN"), // orange
             Level::ERROR => Color::Red.bold().paint("ERROR"),
         }
         .fmt(f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub(crate) mod format;
 
-use ansi_term::{Color, Style};
 use format::{Buffers, ColorLevel, Config, FmtEvent, SpanMode};
+use nu_ansi_term::{Color, Style};
 use std::{
     fmt::{self, Write as _},
     io,


### PR DESCRIPTION
The `ansi_term` crate is no longer maintained (https://rustsec.org/advisories/RUSTSEC-2021-0139). This PR replaces this dependency with the [`nu_ansi_term`](https://crates.io/crates/nu-ansi-term) crate.

Fixes #51 