### PR TITLE
chore: prepare 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-tree"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["David Barsky <me@davidbarsky.com>", "Nathan Whitaker"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This release switches the unmaintained `ansi_term` crate with `nu_ansi_term` (#52).