### PR TITLE
Don't crash if ctx is in a span but event isn't

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,14 +307,10 @@ where
         let mut event_buf = &mut bufs.current_buf;
 
         // printing the indentation
-        let indent = if ctx.current_span().id().is_some() {
-            // size hint isn't implemented on Scope.
-            ctx.event_scope(event)
-                .expect("Unable to get span scope; this is a bug")
-                .count()
-        } else {
-            0
-        };
+        let indent = ctx
+            .event_scope(event)
+            .map(|scope| scope.count())
+            .unwrap_or(0);
 
         // check if this event occurred in the context of a span.
         // if it has, get the start time of this span.


### PR DESCRIPTION
This can occur when there are active spans, but all of the active spans are filtered out by a per-layer filter, so don't show up to us.

I'm not sure if this is considered more a tracing bug or a tracing-tree bug, but this fixed the crash for me, so I'm submitting it here for discussion.