### PR TITLE
Format and print time at which event has occurred

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["r
 nu-ansi-term = "0.46.0"
 atty = "0.2"
 tracing-log = { version = "0.1", optional = true }
+time = { version = "0.3.20", features = ["formatting", "local-offset"] }
 
 [features]
 default = ["tracing-log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["r
 nu-ansi-term = "0.46.0"
 atty = "0.2"
 tracing-log = { version = "0.1", optional = true }
-time = { version = "0.3.20", features = ["formatting", "local-offset"] }
+time = { version = "0.3.20", optional = true, features = ["formatting", "local-offset"] }
 
 [features]
 default = ["tracing-log"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,7 @@ where
         self.timer
             .format_time(&mut event_buf)
             .expect("Unable to write time to buffer");
+        write!(event_buf, " ").expect("Unable to write to buffer");
 
         // printing the indentation
         let indent = ctx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ impl<S, W, FT> Layer<S> for HierarchicalLayer<W, FT>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
     W: for<'writer> MakeWriter<'writer> + 'static,
-    FT: FormatTime + 'static, // TODO(TmLev): Maybe it doesn't have to be static?
+    FT: FormatTime + 'static,
 {
     fn on_new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
         let span = ctx.span(id).expect("in new_span but span does not exist");
@@ -327,7 +327,6 @@ where
 
         // Time.
 
-        // TODO(TmLev): Error handling?
         self.timer
             .format_time(&mut event_buf)
             .expect("Unable to write time to buffer");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,10 +327,18 @@ where
 
         // Time.
 
-        self.timer
-            .format_time(&mut event_buf)
-            .expect("Unable to write time to buffer");
-        write!(event_buf, " ").expect("Unable to write to buffer");
+        {
+            let prev_buffer_len = event_buf.len();
+
+            self.timer
+                .format_time(&mut event_buf)
+                .expect("Unable to write time to buffer");
+
+            // Something was written to the buffer, pad it with a space.
+            if prev_buffer_len < event_buf.len() {
+                write!(event_buf, " ").expect("Unable to write to buffer");
+            }
+        }
 
         // printing the indentation
         let indent = ctx

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,101 @@
+/// A type that can measure and format the current time.
+///
+/// This trait is used by [HierarchicalLayer] to include a timestamp with each
+/// [Event] when it is logged.
+///
+/// Notable default implementations of this trait are [OffsetDateTime] and `()`.
+/// The former prints the current time as reported by [time's OffsetDateTime]
+/// (note that it may panic! make sure to check out the docs for the [OffsetDateTime]),
+/// and the latter does not print the current time at all.
+///
+/// Inspired by the [FormatTime] trait from [tracing-subscriber].
+///
+/// [HierarchicalLayer]: crate::HierarchicalLayer
+/// [Event]: tracing_core::Event
+/// [time's OffsetDateTime]: time::OffsetDateTime
+/// [FormatTime]: tracing_subscriber::fmt::time::FormatTime
+/// [tracing-subscriber]: tracing_subscriber
+// NB:
+//   We can't use `tracing_subscriber::fmt::format::Writer`
+//   since it doesn't have a public constructor.
+pub trait FormatTime {
+    fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Default do-nothing time formatter.
+impl FormatTime for () {
+    fn format_time(&self, _w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Retrieve and print the current wall-clock time.
+///
+/// # Panics
+///
+/// Panics if [time crate] cannot determine the local UTC offset.
+///
+/// [time crate]: time
+// NB:
+//   Can't use `tracing_subscriber::fmt::time::SystemTime` since it uses
+//   private `datetime` module to format the actual time.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub struct OffsetDateTime;
+
+impl FormatTime for OffsetDateTime {
+    fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        let time = time::OffsetDateTime::now_local().expect("time offset cannot be determined");
+        write!(w, "{}", time)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Retrieve and print the relative elapsed wall-clock time since an epoch.
+///
+/// The `Default` implementation for `Uptime` makes the epoch the current time.
+// NB: Copy-pasted from `tracing-subscriber::fmt::time::Uptime`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Uptime {
+    epoch: std::time::Instant,
+}
+
+impl Default for Uptime {
+    fn default() -> Self {
+        Uptime {
+            epoch: std::time::Instant::now(),
+        }
+    }
+}
+
+impl From<std::time::Instant> for Uptime {
+    fn from(epoch: std::time::Instant) -> Self {
+        Uptime { epoch }
+    }
+}
+
+impl FormatTime for Uptime {
+    fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        let e = self.epoch.elapsed();
+        write!(w, "{:4}.{:09}s", e.as_secs(), e.subsec_nanos())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl<'a, F> FormatTime for &'a F
+where
+    F: FormatTime,
+{
+    fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        (*self).format_time(w)
+    }
+}
+
+// NB:
+//   Can't impl for `fn(&mut impl std::fmt::Write)` since impl trait is not allowed
+//   outside of function and inherent method return types for now.

--- a/src/time.rs
+++ b/src/time.rs
@@ -33,6 +33,19 @@ impl FormatTime for () {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Retrieve and print the current wall-clock time in UTC timezone.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub struct UtcDateTime;
+
+impl FormatTime for UtcDateTime {
+    fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        let time = time::OffsetDateTime::now_utc();
+        write!(w, "{} {}", time.date(), time.time())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 /// Retrieve and print the current wall-clock time.
 ///
 /// # Panics

--- a/src/time.rs
+++ b/src/time.rs
@@ -81,7 +81,7 @@ impl From<std::time::Instant> for Uptime {
 impl FormatTime for Uptime {
     fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
         let e = self.epoch.elapsed();
-        write!(w, "{:4}.{:09}s", e.as_secs(), e.subsec_nanos())
+        write!(w, "{:4}.{:06}s", e.as_secs(), e.subsec_micros())
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -3,9 +3,9 @@
 /// This trait is used by [HierarchicalLayer] to include a timestamp with each
 /// [Event] when it is logged.
 ///
-/// Notable default implementations of this trait are [OffsetDateTime] and `()`.
+/// Notable default implementations of this trait are [LocalDateTime] and `()`.
 /// The former prints the current time as reported by [time's OffsetDateTime]
-/// (note that it may panic! make sure to check out the docs for the [OffsetDateTime]),
+/// (note that it may panic! make sure to check out the docs for the [LocalDateTime]),
 /// and the latter does not print the current time at all.
 ///
 /// Inspired by the [FormatTime] trait from [tracing-subscriber].
@@ -44,9 +44,9 @@ impl FormatTime for () {
 //   Can't use `tracing_subscriber::fmt::time::SystemTime` since it uses
 //   private `datetime` module to format the actual time.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
-pub struct OffsetDateTime;
+pub struct LocalDateTime;
 
-impl FormatTime for OffsetDateTime {
+impl FormatTime for LocalDateTime {
     fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
         let time = time::OffsetDateTime::now_local().expect("time offset cannot be determined");
         write!(w, "{}", time)

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,7 +5,8 @@
 ///
 /// Notable default implementations of this trait are [LocalDateTime] and `()`.
 /// The former prints the current time as reported by [time's OffsetDateTime]
-/// (note that it may panic! make sure to check out the docs for the [LocalDateTime]),
+/// (note that it requires a `time` feature to be enabled and may panic!
+/// make sure to check out the docs for the [LocalDateTime]),
 /// and the latter does not print the current time at all.
 ///
 /// Inspired by the [FormatTime] trait from [tracing-subscriber].
@@ -34,9 +35,11 @@ impl FormatTime for () {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Retrieve and print the current wall-clock time in UTC timezone.
+#[cfg(feature = "time")]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct UtcDateTime;
 
+#[cfg(feature = "time")]
 impl FormatTime for UtcDateTime {
     fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
         let time = time::OffsetDateTime::now_utc();
@@ -56,9 +59,11 @@ impl FormatTime for UtcDateTime {
 // NB:
 //   Can't use `tracing_subscriber::fmt::time::SystemTime` since it uses
 //   private `datetime` module to format the actual time.
+#[cfg(feature = "time")]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub struct LocalDateTime;
 
+#[cfg(feature = "time")]
 impl FormatTime for LocalDateTime {
     fn format_time(&self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
         let time = time::OffsetDateTime::now_local().expect("time offset cannot be determined");

--- a/tests/format_time.rs
+++ b/tests/format_time.rs
@@ -1,0 +1,79 @@
+use std::{
+    fmt::Write,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use tracing::{span, Level};
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+use tracing_tree::{time::FormatTime, HierarchicalLayer};
+
+#[derive(Debug)]
+struct FormatTimeCounter(Arc<AtomicU64>);
+
+impl FormatTime for FormatTimeCounter {
+    fn format_time(&self, _w: &mut impl Write) -> std::fmt::Result {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[test]
+fn format_time_num_calls() {
+    let num_called = Arc::new(AtomicU64::new(0));
+    let format_time_counter = FormatTimeCounter(Arc::clone(&num_called));
+
+    let layer = HierarchicalLayer::default()
+        .with_writer(std::io::stdout)
+        .with_indent_lines(true)
+        .with_indent_amount(2)
+        .with_timer(format_time_counter)
+        .with_thread_names(true)
+        .with_thread_ids(true)
+        .with_verbose_exit(true)
+        .with_verbose_entry(true)
+        .with_targets(true);
+
+    let subscriber = Registry::default().with(layer);
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let test_span = span!(Level::TRACE, "format-time-num-calls-test", version = %0.1);
+    let _e = test_span.enter();
+
+    tracing::info!("first event");
+    assert_eq!(num_called.load(Ordering::Relaxed), 1);
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    tracing::info!("second event");
+    assert_eq!(num_called.load(Ordering::Relaxed), 2);
+
+    let nested_span = span!(Level::TRACE, "nested-span");
+    nested_span.in_scope(|| {
+        tracing::debug!("nested event");
+        assert_eq!(num_called.load(Ordering::Relaxed), 3);
+
+        tracing::info!("important nested event");
+        assert_eq!(num_called.load(Ordering::Relaxed), 4);
+    });
+    drop(nested_span);
+
+    instrumented_function();
+    assert_eq!(num_called.load(Ordering::Relaxed), 6);
+
+    tracing::info!("exiting");
+    assert_eq!(num_called.load(Ordering::Relaxed), 7);
+}
+
+#[tracing::instrument]
+fn instrumented_function() {
+    tracing::info!("instrumented function");
+    nested_instrumented_function();
+}
+
+#[tracing::instrument]
+fn nested_instrumented_function() {
+    tracing::warn!("nested instrumented function");
+}


### PR DESCRIPTION
As discussed in #49, new `FormatTime` trait is introduced and implemented for a few basic scenarios:

* `()` – do-nothing time formatter.
* `Uptime` – almost a copy-pasta from [tracing_subscriber](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/time/struct.Uptime.html). Changed nanos to micros.
* `LocalDateTime` – current wall-clock time in the current timezone.
* `UtcDateTime` – current wall-clock time in the UTC timezone.

Here's an example of how it looks with `UtcDateTime`:

<details>

<summary>
  Logs from `examples/basic.rs`
</summary>

```logs
1:main┐basic::hierarchical-example version=0.1
1:main├┐basic::hierarchical-example version=0.1
1:main│└┐basic::server host="localhost", port=8080
1:main│ ├─2023-03-31 10:27:25.122113 0ms  INFO basic starting
1:main│ ├─2023-03-31 10:27:25.427151 305ms  INFO basic listening
1:main│ ├┐basic::server host="localhost", port=8080
1:main│ │└┐basic::conn peer_addr="82.9.9.9", port=42381
1:main│ │ ├─2023-03-31 10:27:25.427267 0ms DEBUG basic connected
1:main│ │ ├─2023-03-31 10:27:25.728098 300ms DEBUG basic message received, length=2
1:main│ │┌┘basic::conn peer_addr="82.9.9.9", port=42381
1:main│ ├┘basic::server host="localhost", port=8080
1:main│ ├┐basic::server host="localhost", port=8080
1:main│ │└┐basic::conn peer_addr="8.8.8.8", port=18230
1:main│ │ ├─2023-03-31 10:27:26.0303 302ms DEBUG basic connected
1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
1:main│ ├┘basic::server host="localhost", port=8080
1:main│ ├┐basic::server host="localhost", port=8080
1:main│ │└┐basic::foomp 42 <- format string, normal_var=43
1:main│ │ ├─2023-03-31 10:27:26.030431 0ms ERROR basic hello
1:main│ │┌┘basic::foomp 42 <- format string, normal_var=43
1:main│ ├┘basic::server host="localhost", port=8080
1:main│ ├┐basic::server host="localhost", port=8080
1:main│ │└┐basic::conn peer_addr="82.9.9.9", port=42381
1:main│ │ ├─2023-03-31 10:27:26.030491 0ms  WARN basic weak encryption requested, algo="xor"
1:main│ │ ├─2023-03-31 10:27:26.331355 300ms DEBUG basic response sent, length=8
1:main│ │ ├─2023-03-31 10:27:26.331516 301ms DEBUG basic disconnected
1:main│ │┌┘basic::conn peer_addr="82.9.9.9", port=42381
1:main│ ├┘basic::server host="localhost", port=8080
1:main│ ├┐basic::server host="localhost", port=8080
1:main│ │└┐basic::conn peer_addr="8.8.8.8", port=18230
1:main│ │ ├─2023-03-31 10:27:26.331738 0ms DEBUG basic message received, length=5
1:main│ │ ├─2023-03-31 10:27:26.633213 301ms DEBUG basic response sent, length=8
1:main│ │ ├─2023-03-31 10:27:26.633372 301ms DEBUG basic disconnected
1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
1:main│ ├┘basic::server host="localhost", port=8080
1:main│ ├─2023-03-31 10:27:26.633815 1511ms  WARN basic internal error
1:main│ ├─2023-03-31 10:27:26.633901 1511ms ERROR basic this is a log message
1:main│ ├─2023-03-31 10:27:26.633946 1511ms  INFO basic exit
1:main│┌┘basic::server host="localhost", port=8080
1:main├┘basic::hierarchical-example version=0.1
1:main┘basic::hierarchical-example version=0.1
```

</details>

Closes #48. Supersedes #49.