### PR TITLE
Allow publishing via a github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: true
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: true
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Determine which version we're about to publish, so we can tag it appropriately.
+      # If the tag already exists, then we've already published this version.
+      - name: Determine current version
+        id: version-check
+        run: |
+          # Fail on first error, on undefined variables, and on errors in pipes.
+          set -euo pipefail
+          export VERSION="$(cargo metadata --format-version 1 | \
+            jq --arg crate_name tracing-tree --exit-status -r \
+                '.packages[] | select(.name == $crate_name) | .version')"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$(git tag -l "$VERSION")" != '' ]]; then
+            echo "Aborting: Version $VERSION is already published, we found its tag in the repo."
+            exit 1
+          fi
+
+      # TODO: Replace this with the cargo-semver-checks v2 GitHub Action when it's stabilized:
+      #       https://github.com/obi1kenobi/cargo-semver-checks-action/pull/21
+      - name: Semver-check
+        run: |
+          # Fail on first error, on undefined variables, and on errors in pipes.
+          set -euo pipefail
+          cargo install --locked cargo-semver-checks
+          cargo semver-checks check-release
+
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Tag the version
+        run: |
+          # Fail on first error, on undefined variables, and on errors in pipes.
+          set -euo pipefail
+          git tag "${{ steps.version-check.outputs.version }}"
+          git push origin "${{ steps.version-check.outputs.version }}"
+
+      - uses: taiki-e/create-gh-release-action@v1
+        name: Create GitHub release
+        with:
+          branch: main
+          ref: refs/tags/${{ steps.version-check.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action must be manually triggered.

It does multiple things:

* It checks whether the version bump follows semver via `cargo-semver-checks`.
* It tags the current commit with the version from the Cargo.toml.
* It publishes the version to crates.io via a token `CARGO_REGISTRY_TOKEN` that we'll need to put into this repo's secrets list.