### PR TITLE
improve the formatting of the example outputs

### DIFF
--- a/examples/basic.stdout
+++ b/examples/basic.stdout
@@ -1,41 +1,41 @@
 1:main┐basic::hierarchical-example version=0.1
 1:main├┐basic::hierarchical-example version=0.1
 1:main│└┐basic::server host="localhost", port=8080
-1:main│ ├─  ms INFO basic starting
-1:main│ ├─  s  INFO basic listening
+1:main│ ├─  Xms INFO basic starting
+1:main│ ├─  Xs  INFO basic listening
 1:main│ ├┐basic::server host="localhost", port=8080
 1:main│ │└┐basic::conn peer_addr="82.9.9.9", port=42381
-1:main│ │ ├─  ms DEBUG basic connected
-1:main│ │ ├─ms DEBUG basic message received, length=2
+1:main│ │ ├─  Xms DEBUG basic connected
+1:main│ │ ├─  Xms DEBUG basic message received, length=2
 1:main│ │┌┘basic::conn peer_addr="82.9.9.9", port=42381
 1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├┐basic::server host="localhost", port=8080
 1:main│ │└┐basic::conn peer_addr="8.8.8.8", port=18230
-1:main│ │ ├─ms DEBUG basic connected
+1:main│ │ ├─  Xms DEBUG basic connected
 1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
 1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├┐basic::server host="localhost", port=8080
 1:main│ │└┐basic::foomp 42 <- format string, normal_var=43
-1:main│ │ ├─  ms ERROR basic hello
+1:main│ │ ├─  Xms ERROR basic hello
 1:main│ │┌┘basic::foomp 42 <- format string, normal_var=43
 1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├┐basic::server host="localhost", port=8080
 1:main│ │└┐basic::conn peer_addr="82.9.9.9", port=42381
-1:main│ │ ├─  ms WARN basic weak encryption requested, algo="xor"
-1:main│ │ ├─ms DEBUG basic response sent, length=8
-1:main│ │ ├─ms DEBUG basic disconnected
+1:main│ │ ├─  Xms WARN basic weak encryption requested, algo="xor"
+1:main│ │ ├─  Xms DEBUG basic response sent, length=8
+1:main│ │ ├─  Xms DEBUG basic disconnected
 1:main│ │┌┘basic::conn peer_addr="82.9.9.9", port=42381
 1:main│ ├┘basic::server host="localhost", port=8080
 1:main│ ├┐basic::server host="localhost", port=8080
 1:main│ │└┐basic::conn peer_addr="8.8.8.8", port=18230
-1:main│ │ ├─  ms DEBUG basic message received, length=5
-1:main│ │ ├─ms DEBUG basic response sent, length=8
-1:main│ │ ├─ms DEBUG basic disconnected
+1:main│ │ ├─  Xms DEBUG basic message received, length=5
+1:main│ │ ├─  Xms DEBUG basic response sent, length=8
+1:main│ │ ├─  Xms DEBUG basic disconnected
 1:main│ │┌┘basic::conn peer_addr="8.8.8.8", port=18230
 1:main│ ├┘basic::server host="localhost", port=8080
-1:main│ ├─  s  WARN basic internal error
-1:main│ ├─  s  ERROR basic this is a log message
-1:main│ ├─  s  INFO basic exit
+1:main│ ├─  Xs  WARN basic internal error
+1:main│ ├─  Xs  ERROR basic this is a log message
+1:main│ ├─  Xs  INFO basic exit
 1:main│┌┘basic::server host="localhost", port=8080
 1:main├┘basic::hierarchical-example version=0.1
 1:main┘basic::hierarchical-example version=0.1

--- a/examples/quiet.stdout
+++ b/examples/quiet.stdout
@@ -1,28 +1,28 @@
 1:main┐quiet::hierarchical-example version=0.1
 1:main├─┐quiet::server host="localhost", port=8080
-1:main│ ├─  ms INFO quiet starting
-1:main│ ├─ms INFO quiet listening
+1:main│ ├─  Xms INFO quiet starting
+1:main│ ├─  Xms INFO quiet listening
 1:main│ ├─┐quiet::conn peer_addr="82.9.9.9", port=42381
-1:main│ │ ├─  ms DEBUG quiet connected
-1:main│ │ ├─ms DEBUG quiet message received, length=2
+1:main│ │ ├─  Xms DEBUG quiet connected
+1:main│ │ ├─  Xms DEBUG quiet message received, length=2
 1:main│ ├─┘
 1:main│ ├─┐quiet::conn peer_addr="8.8.8.8", port=18230
-1:main│ │ ├─ms DEBUG quiet connected
+1:main│ │ ├─  Xms DEBUG quiet connected
 1:main│ ├─┘
 1:main│ ├─┐quiet::foomp 42 <- format string, normal_var=43
-1:main│ │ ├─  ms ERROR quiet hello
+1:main│ │ ├─  Xms ERROR quiet hello
 1:main│ ├─┘
 1:main│ ├─┐quiet::conn peer_addr="82.9.9.9", port=42381
-1:main│ │ ├─  ms WARN quiet weak encryption requested, algo="xor"
-1:main│ │ ├─ms DEBUG quiet response sent, length=8
-1:main│ │ ├─ms DEBUG quiet disconnected
+1:main│ │ ├─  Xms WARN quiet weak encryption requested, algo="xor"
+1:main│ │ ├─  Xms DEBUG quiet response sent, length=8
+1:main│ │ ├─  Xms DEBUG quiet disconnected
 1:main│ ├─┘
 1:main│ ├─┐quiet::conn peer_addr="8.8.8.8", port=18230
-1:main│ │ ├─  ms DEBUG quiet message received, length=5
-1:main│ │ ├─ms DEBUG quiet response sent, length=8
-1:main│ │ ├─ms DEBUG quiet disconnected
+1:main│ │ ├─  Xms DEBUG quiet message received, length=5
+1:main│ │ ├─  Xms DEBUG quiet response sent, length=8
+1:main│ │ ├─  Xms DEBUG quiet disconnected
 1:main│ ├─┘
-1:main│ ├─  s  WARN quiet internal error
-1:main│ ├─  s  INFO quiet exit
+1:main│ ├─  Xs  WARN quiet internal error
+1:main│ ├─  Xs  INFO quiet exit
 1:main├─┘
 1:main┘

--- a/examples/stderr.stderr
+++ b/examples/stderr.stderr
@@ -1,109 +1,109 @@
 ┐fibonacci_seq{to=5}
-├─  ms DEBUG Pushing 0 fibonacci
+├─  Xms DEBUG Pushing 0 fibonacci
 ├─┐nth_fibonacci{n=0}
-│ ├─  ms DEBUG Base case
+│ ├─  Xms DEBUG Base case
 ├─┘
-├─  ms DEBUG Pushing 1 fibonacci
+├─  Xms DEBUG Pushing 1 fibonacci
 ├─┐nth_fibonacci{n=1}
-│ ├─  ms DEBUG Base case
+│ ├─  Xms DEBUG Base case
 ├─┘
-├─  ms DEBUG Pushing 2 fibonacci
+├─  Xms DEBUG Pushing 2 fibonacci
 ├─┐nth_fibonacci{n=2}
-│ ├─  ms DEBUG Recursing
+│ ├─  Xms DEBUG Recursing
 │ ├─┐nth_fibonacci{n=1}
-│ │ ├─  ms DEBUG Base case
+│ │ ├─  Xms DEBUG Base case
 │ ├─┘
 │ ├─┐nth_fibonacci{n=0}
-│ │ ├─  ms DEBUG Base case
+│ │ ├─  Xms DEBUG Base case
 │ ├─┘
 ├─┘
-├─  ms DEBUG Pushing 3 fibonacci
+├─  Xms DEBUG Pushing 3 fibonacci
 ├─┐nth_fibonacci{n=3}
-│ ├─  ms DEBUG Recursing
+│ ├─  Xms DEBUG Recursing
 │ ├─┐nth_fibonacci{n=2}
-│ │ ├─  ms DEBUG Recursing
+│ │ ├─  Xms DEBUG Recursing
 │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ ├─  ms DEBUG Base case
+│ │ │ ├─  Xms DEBUG Base case
 │ │ ├─┘
 │ │ ├─┐nth_fibonacci{n=0}
-│ │ │ ├─  ms DEBUG Base case
+│ │ │ ├─  Xms DEBUG Base case
 │ │ ├─┘
 │ ├─┘
 │ ├─┐nth_fibonacci{n=1}
-│ │ ├─  ms DEBUG Base case
+│ │ ├─  Xms DEBUG Base case
 │ ├─┘
 ├─┘
-├─  ms DEBUG Pushing 4 fibonacci
+├─  Xms DEBUG Pushing 4 fibonacci
 ├─┐nth_fibonacci{n=4}
-│ ├─  ms DEBUG Recursing
+│ ├─  Xms DEBUG Recursing
 │ ├─┐nth_fibonacci{n=3}
-│ │ ├─  ms DEBUG Recursing
+│ │ ├─  Xms DEBUG Recursing
 │ │ ├─┐nth_fibonacci{n=2}
-│ │ │ ├─  ms DEBUG Recursing
+│ │ │ ├─  Xms DEBUG Recursing
 │ │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ │ ├─┐nth_fibonacci{n=0}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ ├─┘
 │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ ├─  ms DEBUG Base case
+│ │ │ ├─  Xms DEBUG Base case
 │ │ ├─┘
 │ ├─┘
 │ ├─┐nth_fibonacci{n=2}
-│ │ ├─  ms DEBUG Recursing
+│ │ ├─  Xms DEBUG Recursing
 │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ ├─  ms DEBUG Base case
+│ │ │ ├─  Xms DEBUG Base case
 │ │ ├─┘
 │ │ ├─┐nth_fibonacci{n=0}
-│ │ │ ├─  ms DEBUG Base case
+│ │ │ ├─  Xms DEBUG Base case
 │ │ ├─┘
 │ ├─┘
 ├─┘
-├─  ms DEBUG Pushing 5 fibonacci
+├─  Xms DEBUG Pushing 5 fibonacci
 ├─┐nth_fibonacci{n=5}
-│ ├─  ms DEBUG Recursing
+│ ├─  Xms DEBUG Recursing
 │ ├─┐nth_fibonacci{n=4}
-│ │ ├─  ms DEBUG Recursing
+│ │ ├─  Xms DEBUG Recursing
 │ │ ├─┐nth_fibonacci{n=3}
-│ │ │ ├─  ms DEBUG Recursing
+│ │ │ ├─  Xms DEBUG Recursing
 │ │ │ ├─┐nth_fibonacci{n=2}
-│ │ │ │ ├─  ms DEBUG Recursing
+│ │ │ │ ├─  Xms DEBUG Recursing
 │ │ │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ │ ├─┘
 │ │ │ │ ├─┐nth_fibonacci{n=0}
-│ │ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ │ ├─┘
 │ │ │ ├─┘
 │ │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ ├─┘
 │ │ ├─┐nth_fibonacci{n=2}
-│ │ │ ├─  ms DEBUG Recursing
+│ │ │ ├─  Xms DEBUG Recursing
 │ │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ │ ├─┐nth_fibonacci{n=0}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ ├─┘
 │ ├─┘
 │ ├─┐nth_fibonacci{n=3}
-│ │ ├─  ms DEBUG Recursing
+│ │ ├─  Xms DEBUG Recursing
 │ │ ├─┐nth_fibonacci{n=2}
-│ │ │ ├─  ms DEBUG Recursing
+│ │ │ ├─  Xms DEBUG Recursing
 │ │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ │ ├─┐nth_fibonacci{n=0}
-│ │ │ │ ├─  ms DEBUG Base case
+│ │ │ │ ├─  Xms DEBUG Base case
 │ │ │ ├─┘
 │ │ ├─┘
 │ │ ├─┐nth_fibonacci{n=1}
-│ │ │ ├─  ms DEBUG Base case
+│ │ │ ├─  Xms DEBUG Base case
 │ │ ├─┘
 │ ├─┘
 ├─┘

--- a/examples/wraparound.stdout
+++ b/examples/wraparound.stdout
@@ -1,96 +1,96 @@
 1:main┐wraparound::recurse i=0
-1:main├─  ms WARN wraparound boop
+1:main├─  Xms WARN wraparound boop
 1:main├─┐wraparound::recurse i=1
-1:main│ ├─  ms WARN wraparound boop
+1:main│ ├─  Xms WARN wraparound boop
 1:main│ ├─┐wraparound::recurse i=2
-1:main│ │ ├─  ms WARN wraparound boop
+1:main│ │ ├─  Xms WARN wraparound boop
 1:main│ │ ├─┐wraparound::recurse i=3
-1:main│ │ │ ├─  ms WARN wraparound boop
+1:main│ │ │ ├─  Xms WARN wraparound boop
 1:main│ │ │ ├─┐wraparound::recurse i=4
 1:main────────┘
-1:main  ms WARN wraparound boop
+1:main  Xms WARN wraparound boop
 1:main┐wraparound::recurse i=5
-1:main├─  ms WARN wraparound boop
+1:main├─  Xms WARN wraparound boop
 1:main├─┐wraparound::recurse i=6
-1:main│ ├─  ms WARN wraparound boop
+1:main│ ├─  Xms WARN wraparound boop
 1:main│ ├─┐wraparound::recurse i=7
-1:main│ │ ├─  ms WARN wraparound boop
+1:main│ │ ├─  Xms WARN wraparound boop
 1:main│ │ ├─┐wraparound::recurse i=8
-1:main│ │ │ ├─  ms WARN wraparound boop
+1:main│ │ │ ├─  Xms WARN wraparound boop
 1:main│ │ │ ├─┐wraparound::recurse i=9
 1:main────────┘
-1:main  ms WARN wraparound boop
+1:main  Xms WARN wraparound boop
 1:main┐wraparound::recurse i=10
-1:main├─  ms WARN wraparound boop
+1:main├─  Xms WARN wraparound boop
 1:main├─┐wraparound::recurse i=11
-1:main│ ├─  ms WARN wraparound boop
+1:main│ ├─  Xms WARN wraparound boop
 1:main│ ├─┐wraparound::recurse i=12
-1:main│ │ ├─  ms WARN wraparound boop
+1:main│ │ ├─  Xms WARN wraparound boop
 1:main│ │ ├─┐wraparound::recurse i=13
-1:main│ │ │ ├─  ms WARN wraparound boop
+1:main│ │ │ ├─  Xms WARN wraparound boop
 1:main│ │ │ ├─┐wraparound::recurse i=14
 1:main────────┘
-1:main  ms WARN wraparound boop
+1:main  Xms WARN wraparound boop
 1:main┐wraparound::recurse i=15
-1:main├─  ms WARN wraparound boop
+1:main├─  Xms WARN wraparound boop
 1:main├─┐wraparound::recurse i=16
-1:main│ ├─  ms WARN wraparound boop
+1:main│ ├─  Xms WARN wraparound boop
 1:main│ ├─┐wraparound::recurse i=17
-1:main│ │ ├─  ms WARN wraparound boop
+1:main│ │ ├─  Xms WARN wraparound boop
 1:main│ │ ├─┐wraparound::recurse i=18
-1:main│ │ │ ├─  ms WARN wraparound boop
+1:main│ │ │ ├─  Xms WARN wraparound boop
 1:main│ │ │ ├─┐wraparound::recurse i=19
 1:main────────┘
-1:main  ms WARN wraparound boop
+1:main  Xms WARN wraparound boop
 1:main┐wraparound::recurse i=20
-1:main├─  ms WARN wraparound boop
+1:main├─  Xms WARN wraparound boop
 1:main├─┐wraparound::recurse i=21
-1:main│ ├─  ms WARN wraparound boop
-1:main│ ├─  ms WARN wraparound bop
+1:main│ ├─  Xms WARN wraparound boop
+1:main│ ├─  Xms WARN wraparound bop
 1:main├─┘
-1:main├─  ms WARN wraparound bop
+1:main├─  Xms WARN wraparound bop
 1:main┘
-1:main  ms WARN wraparound bop
+1:main  Xms WARN wraparound bop
 1:main────────┐
 1:main│ │ │ ├─┘
-1:main│ │ │ ├─  ms WARN wraparound bop
+1:main│ │ │ ├─  Xms WARN wraparound bop
 1:main│ │ ├─┘
-1:main│ │ ├─  ms WARN wraparound bop
+1:main│ │ ├─  Xms WARN wraparound bop
 1:main│ ├─┘
-1:main│ ├─  ms WARN wraparound bop
+1:main│ ├─  Xms WARN wraparound bop
 1:main├─┘
-1:main├─  ms WARN wraparound bop
+1:main├─  Xms WARN wraparound bop
 1:main┘
-1:main  ms WARN wraparound bop
+1:main  Xms WARN wraparound bop
 1:main────────┐
 1:main│ │ │ ├─┘
-1:main│ │ │ ├─  ms WARN wraparound bop
+1:main│ │ │ ├─  Xms WARN wraparound bop
 1:main│ │ ├─┘
-1:main│ │ ├─  ms WARN wraparound bop
+1:main│ │ ├─  Xms WARN wraparound bop
 1:main│ ├─┘
-1:main│ ├─  ms WARN wraparound bop
+1:main│ ├─  Xms WARN wraparound bop
 1:main├─┘
-1:main├─  ms WARN wraparound bop
+1:main├─  Xms WARN wraparound bop
 1:main┘
-1:main  ms WARN wraparound bop
+1:main  Xms WARN wraparound bop
 1:main────────┐
 1:main│ │ │ ├─┘
-1:main│ │ │ ├─  ms WARN wraparound bop
+1:main│ │ │ ├─  Xms WARN wraparound bop
 1:main│ │ ├─┘
-1:main│ │ ├─  ms WARN wraparound bop
+1:main│ │ ├─  Xms WARN wraparound bop
 1:main│ ├─┘
-1:main│ ├─  ms WARN wraparound bop
+1:main│ ├─  Xms WARN wraparound bop
 1:main├─┘
-1:main├─  ms WARN wraparound bop
+1:main├─  Xms WARN wraparound bop
 1:main┘
-1:main  ms WARN wraparound bop
+1:main  Xms WARN wraparound bop
 1:main────────┐
 1:main│ │ │ ├─┘
-1:main│ │ │ ├─  ms WARN wraparound bop
+1:main│ │ │ ├─  Xms WARN wraparound bop
 1:main│ │ ├─┘
-1:main│ │ ├─  ms WARN wraparound bop
+1:main│ │ ├─  Xms WARN wraparound bop
 1:main│ ├─┘
-1:main│ ├─  ms WARN wraparound bop
+1:main│ ├─  Xms WARN wraparound bop
 1:main├─┘
-1:main├─  ms WARN wraparound bop
+1:main├─  Xms WARN wraparound bop
 1:main┘

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -8,8 +8,12 @@ fn main() -> Result<()> {
     config.args.push("feature=\"tracing-log\"".into());
     config.out_dir = Some("target/ui_test".into());
     config.mode = Mode::Run { exit_code: 0 };
-    config.stdout_filter("[0-9]+(ms|s|m)", "$1");
-    config.stderr_filter("[0-9]+(ms|s|m)", "$1");
+    config.stdout_filter("[0-9]{3}(ms|s|m)", "  X$1");
+    config.stdout_filter("[0-9]{2}(ms|s|m)", " X$1");
+    config.stdout_filter("[0-9]{1}(ms|s|m)", "X$1");
+    config.stderr_filter("[0-9]{3}(ms|s|m)", "  X$1");
+    config.stderr_filter("[0-9]{2}(ms|s|m)", " X$1");
+    config.stderr_filter("[0-9]{1}(ms|s|m)", "X$1");
     config.output_conflict_handling = if std::env::args().any(|arg| arg == "--bless") {
         OutputConflictHandling::Bless
     } else {


### PR DESCRIPTION
This should better align the timestamps, while still redacting them, and show placeholders for where the digits go