### PR TITLE
replace README example with embed from examples dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,7 @@ Instrument your application with [tracing](https://github.com/tokio-rs/tracing)
 and get tree-structured summaries of your application activity with timing
 information on the console:
 
-<pre> 
- <b>server</b>{host=&quot;localhost&quot;, port=8080<b>}</b>
-    0ms <b> INFO</b> starting
-    300ms <b> INFO</b> listening
-    <b>conn</b>{peer_addr=&quot;82.9.9.9&quot;, port=42381<b>}</b>
-      0ms <b>DEBUG</b> connected
-      300ms <b>DEBUG</b> message received, length=2
-    <b>conn</b>{peer_addr=&quot;8.8.8.8&quot;, port=18230<b>}</b>
-      300ms <b>DEBUG</b> connected
-    <b>conn</b>{peer_addr=&quot;82.9.9.9&quot;, port=42381<b>}</b>
-      600ms <b> WARN</b> weak encryption requested, algo=&quot;xor&quot;
-      901ms <b>DEBUG</b> response sent, length=8
-      901ms <b>DEBUG</b> disconnected
-    <b>conn</b>{peer_addr=&quot;8.8.8.8&quot;, port=18230<b>}</b>
-      600ms <b>DEBUG</b> message received, length=5
-      901ms <b>DEBUG</b> response sent, length=8
-      901ms <b>DEBUG</b> disconnected
-    1502ms <b> WARN</b> internal error
-    1502ms <b> INFO</b> exit
-</pre>
+https://github.com/davidbarsky/tracing-tree/blob/483cc0a118c3170f4246d6fa4a9f018a00d8f0a9/examples/quiet.stdout#L1-L28
 
 (Format inspired by [slog-term](https://github.com/slog-rs/slog#terminal-output-example))
 


### PR DESCRIPTION
The example in the README no longer accurately reflects the output from the library. This references the quiet example directly.

It will still need to be updated when there are changes to that example