### PR TITLE
Add Configuration for Higher Time Precision with Decimals

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -60,6 +60,8 @@ pub struct Config {
     pub deferred_spans: bool,
     /// Print a label of the span mode (open/close etc).
     pub span_modes: bool,
+    /// Whether to print the time with higher precision.
+    pub higher_precision: bool,
 }
 
 impl Config {
@@ -138,6 +140,13 @@ impl Config {
         }
     }
 
+    pub fn with_higher_precision(self, higher_precision: bool) -> Self {
+        Self {
+            higher_precision,
+            ..self
+        }
+    }
+
     pub(crate) fn prefix(&self) -> String {
         let mut buf = String::new();
         if self.render_thread_ids {
@@ -177,6 +186,7 @@ impl Default for Config {
             bracketed_fields: false,
             deferred_spans: false,
             span_modes: false,
+            higher_precision: false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,12 +440,8 @@ where
             (secs / 60, "m ")
         };
 
-        let n = format!("{n:>3}");
-        format!(
-            "{timestamp}{unit} ",
-            timestamp = self.styled(Style::new().dimmed(), n),
-            unit = self.styled(Style::new().dimmed(), unit),
-        )
+        let timestamp = format!("{n:>3}");
+        self.style_timestamp(timestamp, unit)
     }
 
     fn format_timestamp_with_decimals(&self, start: std::time::Instant) -> String {
@@ -463,10 +459,14 @@ where
             (secs, "s ")
         };
 
-        let n = format!(" {n:.2}");
+        let timestamp = format!(" {n:.2}");
+        self.style_timestamp(timestamp, unit)
+    }
+
+    fn style_timestamp(&self, timestamp: String, unit: &str) -> String {
         format!(
             "{timestamp}{unit} ",
-            timestamp = self.styled(Style::new().dimmed(), n),
+            timestamp = self.styled(Style::new().dimmed(), timestamp),
             unit = self.styled(Style::new().dimmed(), unit),
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,21 +410,16 @@ where
     where
         S: Subscriber + for<'span> LookupSpan<'span>,
     {
-        match ctx.span(id) {
-            // if the event is in a span, get the span's starting point.
-            Some(ctx) => {
-                let ext = ctx.extensions();
-                let data = ext
-                    .get::<Data>()
-                    .expect("Data cannot be found in extensions");
+        let ctx = ctx.span(id)?;
+        let ext = ctx.extensions();
+        let data = ext
+            .get::<Data>()
+            .expect("Data cannot be found in extensions");
 
-                if self.config.higher_precision {
-                    Some(self.format_timestamp_with_decimals(data.start))
-                } else {
-                    Some(self.format_timestamp(data.start))
-                }
-            }
-            None => None,
+        if self.config.higher_precision {
+            Some(self.format_timestamp_with_decimals(data.start))
+        } else {
+            Some(self.format_timestamp(data.start))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,10 +406,10 @@ where
         bufs.flush_current_buf(writer)
     }
 
-    fn get_timestamp<S>(&self, id: &Id ,ctx: &Context<S>,) -> Option<String>
+    fn get_timestamp<S>(&self, id: &Id, ctx: &Context<S>) -> Option<String>
     where
         S: Subscriber + for<'span> LookupSpan<'span>,
-    { 
+    {
         match ctx.span(id) {
             // if the event is in a span, get the span's starting point.
             Some(ctx) => {
@@ -466,7 +466,7 @@ where
             (secs * 1_000.0, "ms")
         } else {
             (secs, "s ")
-        }; 
+        };
 
         let n = format!(" {n:.2}");
         format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,12 +406,11 @@ where
         bufs.flush_current_buf(writer)
     }
 
-    fn get_timestamp<S>(&self, id: &Id, ctx: &Context<S>) -> Option<String>
+    fn get_timestamp<S>(&self, span: SpanRef<S>) -> Option<String>
     where
         S: Subscriber + for<'span> LookupSpan<'span>,
     {
-        let ctx = ctx.span(id)?;
-        let ext = ctx.extensions();
+        let ext = span.extensions();
         let data = ext
             .get::<Data>()
             .expect("Data cannot be found in extensions");
@@ -548,8 +547,8 @@ where
 
         // check if this event occurred in the context of a span.
         // if it has, get the start time of this span.
-        if let Some(id) = ctx.current_span().id() {
-            if let Some(timestamp) = self.get_timestamp(id, &ctx) {
+        if let Some(span) = span {
+            if let Some(timestamp) = self.get_timestamp(span) {
                 write!(&mut event_buf, "{}", timestamp).expect("Unable to write to buffer");
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,14 @@ where
         }
     }
 
+    /// Whether to print the time with higher precision.
+    pub fn with_higher_precision(self, higher_precision: bool) -> Self {
+        Self {
+            config: self.config.with_higher_precision(higher_precision),
+            ..self
+        }
+    }
+
     fn styled(&self, style: Style, text: impl AsRef<str>) -> String {
         if self.config.ansi {
             style.paint(text.as_ref()).to_string()
@@ -397,6 +405,79 @@ where
         let writer = self.make_writer.make_writer();
         bufs.flush_current_buf(writer)
     }
+
+    fn get_timestamp<S>(&self, id: &Id ,ctx: &Context<S>,) -> Option<String>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    { 
+        match ctx.span(id) {
+            // if the event is in a span, get the span's starting point.
+            Some(ctx) => {
+                let ext = ctx.extensions();
+                let data = ext
+                    .get::<Data>()
+                    .expect("Data cannot be found in extensions");
+
+                if self.config.higher_precision {
+                    Some(self.format_timestamp_with_decimals(data.start))
+                } else {
+                    Some(self.format_timestamp(data.start))
+                }
+            }
+            None => None,
+        }
+    }
+
+    fn format_timestamp(&self, start: std::time::Instant) -> String {
+        let elapsed = start.elapsed();
+        let millis = elapsed.as_millis();
+        let secs = elapsed.as_secs();
+
+        // Convert elapsed time to appropriate units: ms, s, or m.
+        // - Less than 1s : use ms
+        // - Less than 1m : use s
+        // - 1m and above : use m
+        let (n, unit) = if millis < 1000 {
+            (millis as _, "ms")
+        } else if secs < 60 {
+            (secs, "s ")
+        } else {
+            (secs / 60, "m ")
+        };
+
+        let n = format!("{n:>3}");
+        format!(
+            "{timestamp}{unit} ",
+            timestamp = self.styled(Style::new().dimmed(), n),
+            unit = self.styled(Style::new().dimmed(), unit),
+        )
+    }
+
+    fn format_timestamp_with_decimals(&self, start: std::time::Instant) -> String {
+        let elapsed = start.elapsed();
+        let nanos = elapsed.as_nanos() as f64;
+        let micros = elapsed.as_micros() as f64;
+        let millis = elapsed.as_millis() as f64;
+
+        // Convert elapsed time to appropriate units: μs, ms, or s.
+        // - Less than 1ms: use μs
+        // - Less than 1s : use ms
+        // - 1s and above : use s
+        let (n, unit) = if micros < 1000.0 {
+            (nanos / 1000.0, "μs")
+        } else if millis < 1000.0 {
+            (micros / 1000.0, "ms")
+        } else {
+            (millis / 1000.0, "s ")
+        }; 
+
+        let n = format!(" {n:.2}");
+        format!(
+            "{timestamp}{unit} ",
+            timestamp = self.styled(Style::new().dimmed(), n),
+            unit = self.styled(Style::new().dimmed(), unit),
+        )
+    }
 }
 
 impl<S, W, FT> Layer<S> for HierarchicalLayer<W, FT>
@@ -475,38 +556,10 @@ where
 
         // check if this event occurred in the context of a span.
         // if it has, get the start time of this span.
-        let start = match span {
-            Some(span) => {
-                // if the event is in a span, get the span's starting point.
-                let ext = span.extensions();
-                let data = ext
-                    .get::<Data>()
-                    .expect("Data cannot be found in extensions");
-
-                Some(data.start)
+        if let Some(id) = ctx.current_span().id() {
+            if let Some(timestamp) = self.get_timestamp(id, &ctx) {
+                write!(&mut event_buf, "{}", timestamp).expect("Unable to write to buffer");
             }
-            None => None,
-        };
-
-        if let Some(start) = start {
-            let elapsed = start.elapsed();
-            let millis = elapsed.as_millis();
-            let secs = elapsed.as_secs();
-            let (n, unit) = if millis < 1000 {
-                (millis as _, "ms")
-            } else if secs < 60 {
-                (secs, "s ")
-            } else {
-                (secs / 60, "m ")
-            };
-            let n = format!("{n:>3}");
-            write!(
-                &mut event_buf,
-                "{timestamp}{unit} ",
-                timestamp = self.styled(Style::new().dimmed(), n),
-                unit = self.styled(Style::new().dimmed(), unit),
-            )
-            .expect("Unable to write to buffer");
         }
 
         #[cfg(feature = "tracing-log")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,21 +454,18 @@ where
     }
 
     fn format_timestamp_with_decimals(&self, start: std::time::Instant) -> String {
-        let elapsed = start.elapsed();
-        let nanos = elapsed.as_nanos() as f64;
-        let micros = elapsed.as_micros() as f64;
-        let millis = elapsed.as_millis() as f64;
+        let secs = start.elapsed().as_secs_f64();
 
         // Convert elapsed time to appropriate units: μs, ms, or s.
         // - Less than 1ms: use μs
         // - Less than 1s : use ms
         // - 1s and above : use s
-        let (n, unit) = if micros < 1000.0 {
-            (nanos / 1000.0, "μs")
-        } else if millis < 1000.0 {
-            (micros / 1000.0, "ms")
+        let (n, unit) = if secs < 0.001 {
+            (secs * 1_000_000.0, "μs")
+        } else if secs < 1.0 {
+            (secs * 1_000.0, "ms")
         } else {
-            (millis / 1000.0, "s ")
+            (secs, "s ")
         }; 
 
         let n = format!(" {n:.2}");


### PR DESCRIPTION
To address https://github.com/davidbarsky/tracing-tree/issues/67, add a new configuration option, `with_higher_precision`. When this option is enabled, the time is displayed with higher precision, including decimal points.

- Added `with_higher_precision` as a configuration option.
- Refactored the existing code in the `on_event` method to separate methods for code reusability[^1]

[^1]: If this PR looks good, I'd like to propose an implementation to address [Issue 17](https://github.com/davidbarsky/tracing-tree/issues/17) based on this as a foundation.

Example Output:
With `higher_precision enabled`, the output will look like this.

```
┐run{hostname="localhost"}
├─ 45.96μs TRACE Request received
├─┐fetch_httpbin{method=GET, path="/"}
│ ├─ 3.70s  DEBUG Response received, backend=httpbin, status=200 OK, cache_status=MISS
├─┘
├─┐fetch_example{method=GET, path="/"}
│ ├─ 587.93ms DEBUG Response received from example, backend=example, status=200 OK, cache_status=HIT
│ ├─┐open_datastore{name="subscriptions"}
│ ├─┘
│ ├─┐read_from_datastore{key="foo@example.com"}
│ │ ├─ 43.04μs  WARN Item found, key=foo@example.com
│ ├─┘
├─┘
├─ 4.29s  TRACE Returning response, status=200 OK
┘
```