### PR TITLE
Version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-tree"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["David Barsky <me@davidbarsky.com>", "Nathan Whitaker"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tracing-tree"
 version = "0.2.5"
-authors = ["David Barsky <me@davidbarsky.com>", "Nathan Whitaker"]
+authors = ["David Barsky <me@davidbarsky.com>", "Nathan Whitaker", "Oli Scherer <tracing-tree@oli-obk.de>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A Tracing Layer which prints a tree of spans and events."

--- a/test_dependencies/Cargo.lock
+++ b/test_dependencies/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "nu-ansi-term",
  "tracing-core",


### PR DESCRIPTION
This release includes

* a MSRV bump to 1.70 (two versions ago)
* better (and configurable) timestamps
* better interleaved printing if multiple threads are emitting spans and events