### PR TITLE
Fix interleaved non-deferred spans

### DIFF
--- a/examples/concurrent_eager.rs
+++ b/examples/concurrent_eager.rs
@@ -1,0 +1,101 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{pin_mut, FutureExt};
+use tracing::Instrument;
+use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
+use tracing_tree::HierarchicalLayer;
+
+fn main() {
+    let layer = HierarchicalLayer::default()
+        .with_writer(std::io::stdout)
+        .with_indent_lines(true)
+        .with_indent_amount(4)
+        .with_thread_names(true)
+        .with_thread_ids(true)
+        .with_span_retrace(true)
+        .with_deferred_spans(false)
+        .with_targets(true);
+
+    let subscriber = Registry::default().with(layer);
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    #[cfg(feature = "tracing-log")]
+    tracing_log::LogTracer::init().unwrap();
+
+    let fut_a = spawn_fut("a", a);
+    pin_mut!(fut_a);
+
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert!(fut_a.poll_unpin(&mut cx).is_pending());
+
+    let fut_b = spawn_fut("b", b);
+    pin_mut!(fut_b);
+
+    assert!(fut_b.poll_unpin(&mut cx).is_pending());
+
+    assert!(fut_a.poll_unpin(&mut cx).is_pending());
+    assert!(fut_b.poll_unpin(&mut cx).is_pending());
+
+    assert!(fut_a.poll_unpin(&mut cx).is_ready());
+    assert!(fut_b.poll_unpin(&mut cx).is_ready());
+}
+
+fn spawn_fut<F: Fn() -> Fut, Fut: Future<Output = ()>>(
+    key: &'static str,
+    inner: F,
+) -> impl Future<Output = ()> {
+    let span = tracing::info_span!("spawn_fut", key);
+
+    async move {
+        countdown(1).await;
+
+        inner().await;
+    }
+    .instrument(span)
+}
+
+fn a() -> impl Future<Output = ()> {
+    let span = tracing::info_span!("a");
+
+    async move {
+        countdown(1).await;
+        tracing::info!("a");
+    }
+    .instrument(span)
+}
+
+fn b() -> impl Future<Output = ()> {
+    let span = tracing::info_span!("b");
+
+    async move {
+        countdown(1).await;
+        tracing::info!("b");
+    }
+    .instrument(span)
+}
+
+fn countdown(count: u32) -> impl Future<Output = ()> {
+    CountdownFuture { count }
+}
+
+struct CountdownFuture {
+    count: u32,
+}
+
+impl Future for CountdownFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.count == 0 {
+            Poll::Ready(())
+        } else {
+            self.count -= 1;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}

--- a/examples/concurrent_eager.rs
+++ b/examples/concurrent_eager.rs
@@ -18,6 +18,7 @@ fn main() {
         .with_thread_ids(true)
         .with_span_retrace(true)
         .with_deferred_spans(false)
+        .with_verbose_entry(true)
         .with_targets(true);
 
     let subscriber = Registry::default().with(layer);

--- a/examples/concurrent_eager.stdout
+++ b/examples/concurrent_eager.stdout
@@ -1,19 +1,15 @@
 1:main┐concurrent_eager::spawn_fut key="a"
 1:main┐concurrent_eager::spawn_fut key="b"
 1:main┐concurrent_eager::spawn_fut key="a"
-1:main├─┐concurrent_eager::spawn_fut key="a"
-1:main│ └─┐concurrent_eager::a 
+1:main├───┐concurrent_eager::a 
 1:main┐concurrent_eager::spawn_fut key="b"
-1:main├─┐concurrent_eager::spawn_fut key="b"
-1:main│ └─┐concurrent_eager::b 
+1:main├───┐concurrent_eager::b 
 1:main┐concurrent_eager::spawn_fut key="a"
-1:main├─┐concurrent_eager::spawn_fut key="a"
-1:main│ └─┐concurrent_eager::a 
+1:main├───┐concurrent_eager::a 
 1:main│   ├───  Xms INFO concurrent_eager a
 1:main├───┘
 1:main┐concurrent_eager::spawn_fut key="b"
-1:main├─┐concurrent_eager::spawn_fut key="b"
-1:main│ └─┐concurrent_eager::b 
+1:main├───┐concurrent_eager::b 
 1:main│   ├───  Xms INFO concurrent_eager b
 1:main├───┘
 1:main┘

--- a/examples/concurrent_eager.stdout
+++ b/examples/concurrent_eager.stdout
@@ -1,0 +1,16 @@
+1:main┐concurrent_eager::spawn_fut key="a"
+1:main┐concurrent_eager::spawn_fut key="b"
+1:main┐concurrent_eager::spawn_fut key="a"
+1:main├───┐concurrent_eager::a 
+1:main┐concurrent_eager::spawn_fut key="b"
+1:main├───┐concurrent_eager::b 
+1:main┐concurrent_eager::spawn_fut key="a"
+1:main├───┐concurrent_eager::a 
+1:main│   ├───  Xms INFO concurrent_eager a
+1:main├───┘
+1:main┐concurrent_eager::spawn_fut key="b"
+1:main├───┐concurrent_eager::b 
+1:main│   ├───  Xms INFO concurrent_eager b
+1:main├───┘
+1:main┘
+1:main┘

--- a/examples/concurrent_eager.stdout
+++ b/examples/concurrent_eager.stdout
@@ -1,15 +1,19 @@
 1:main┐concurrent_eager::spawn_fut key="a"
 1:main┐concurrent_eager::spawn_fut key="b"
 1:main┐concurrent_eager::spawn_fut key="a"
-1:main├───┐concurrent_eager::a 
+1:main├─┐concurrent_eager::spawn_fut key="a"
+1:main│ └─┐concurrent_eager::a 
 1:main┐concurrent_eager::spawn_fut key="b"
-1:main├───┐concurrent_eager::b 
+1:main├─┐concurrent_eager::spawn_fut key="b"
+1:main│ └─┐concurrent_eager::b 
 1:main┐concurrent_eager::spawn_fut key="a"
-1:main├───┐concurrent_eager::a 
+1:main├─┐concurrent_eager::spawn_fut key="a"
+1:main│ └─┐concurrent_eager::a 
 1:main│   ├───  Xms INFO concurrent_eager a
 1:main├───┘
 1:main┐concurrent_eager::spawn_fut key="b"
-1:main├───┐concurrent_eager::b 
+1:main├─┐concurrent_eager::spawn_fut key="b"
+1:main│ └─┐concurrent_eager::b 
 1:main│   ├───  Xms INFO concurrent_eager b
 1:main├───┘
 1:main┘

--- a/examples/concurrent_verbose.stdout
+++ b/examples/concurrent_verbose.stdout
@@ -1,24 +1,21 @@
 1:main┐concurrent_verbose::hierarchical-example version=0.1
-1:main├───┐concurrent_verbose::server host="localhost", port=8080
+1:main├─┐concurrent_verbose::hierarchical-example version=0.1
+1:main│ └─┐concurrent_verbose::server host="localhost", port=8080
 1:main│   ├───  Xms INFO concurrent_verbose starting
 1:main│   ├───  Xs  INFO concurrent_verbose listening
 1:main│   ├───  Xs  DEBUG concurrent_verbose starting countdowns
-1:main│   ├─┐concurrent_verbose::server host="localhost", port=8080
-1:main│   │ └─┐concurrent_verbose::countdowns 
-1:main│   │   ├───┐concurrent_verbose::countdown_a 
-1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="a", count=3
-1:main│   │   ├─┐concurrent_verbose::countdowns 
-1:main│   │   │ └─┐concurrent_verbose::countdown_b 
-1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="b", count=5
-1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="b", count=4
+1:main│   ├───┐concurrent_verbose::countdowns 
 1:main│   │   ├─┐concurrent_verbose::countdowns 
 1:main│   │   │ └─┐concurrent_verbose::countdown_a 
+1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="a", count=3
+1:main│   │   ├───┐concurrent_verbose::countdown_b 
+1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="b", count=5
+1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="b", count=4
+1:main│   │   ├───┐concurrent_verbose::countdown_a 
 1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="a", count=2
-1:main│   ├─┐concurrent_verbose::server host="localhost", port=8080
-1:main│   │ └─┐concurrent_verbose::conn peer_addr="82.9.9.9", port=42381
+1:main│   ├───┐concurrent_verbose::conn peer_addr="82.9.9.9", port=42381
 1:main│   │   ├───  Xms WARN concurrent_verbose peer1 warning
-1:main│   ├─┐concurrent_verbose::server host="localhost", port=8080
-1:main│   │ └─┐concurrent_verbose::countdowns 
+1:main│   ├───┐concurrent_verbose::countdowns 
 1:main│   │   ├───  Xms INFO concurrent_verbose finished polling countdowns
 1:main│   │   │ ┌─┘concurrent_verbose::countdown_b 
 1:main│   │   ├─┘concurrent_verbose::countdowns 

--- a/examples/concurrent_verbose.stdout
+++ b/examples/concurrent_verbose.stdout
@@ -1,21 +1,24 @@
 1:main┐concurrent_verbose::hierarchical-example version=0.1
-1:main├─┐concurrent_verbose::hierarchical-example version=0.1
-1:main│ └─┐concurrent_verbose::server host="localhost", port=8080
+1:main├───┐concurrent_verbose::server host="localhost", port=8080
 1:main│   ├───  Xms INFO concurrent_verbose starting
 1:main│   ├───  Xs  INFO concurrent_verbose listening
 1:main│   ├───  Xs  DEBUG concurrent_verbose starting countdowns
-1:main│   ├───┐concurrent_verbose::countdowns 
-1:main│   │   ├─┐concurrent_verbose::countdowns 
-1:main│   │   │ └─┐concurrent_verbose::countdown_a 
+1:main│   ├─┐concurrent_verbose::server host="localhost", port=8080
+1:main│   │ └─┐concurrent_verbose::countdowns 
+1:main│   │   ├───┐concurrent_verbose::countdown_a 
 1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="a", count=3
-1:main│   │   ├───┐concurrent_verbose::countdown_b 
+1:main│   │   ├─┐concurrent_verbose::countdowns 
+1:main│   │   │ └─┐concurrent_verbose::countdown_b 
 1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="b", count=5
 1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="b", count=4
-1:main│   │   ├───┐concurrent_verbose::countdown_a 
+1:main│   │   ├─┐concurrent_verbose::countdowns 
+1:main│   │   │ └─┐concurrent_verbose::countdown_a 
 1:main│   │   │   ├───  Xms DEBUG concurrent_verbose polling countdown, label="a", count=2
-1:main│   ├───┐concurrent_verbose::conn peer_addr="82.9.9.9", port=42381
+1:main│   ├─┐concurrent_verbose::server host="localhost", port=8080
+1:main│   │ └─┐concurrent_verbose::conn peer_addr="82.9.9.9", port=42381
 1:main│   │   ├───  Xms WARN concurrent_verbose peer1 warning
-1:main│   ├───┐concurrent_verbose::countdowns 
+1:main│   ├─┐concurrent_verbose::server host="localhost", port=8080
+1:main│   │ └─┐concurrent_verbose::countdowns 
 1:main│   │   ├───  Xms INFO concurrent_verbose finished polling countdowns
 1:main│   │   │ ┌─┘concurrent_verbose::countdown_b 
 1:main│   │   ├─┘concurrent_verbose::countdowns 

--- a/examples/deferred.stdout
+++ b/examples/deferred.stdout
@@ -1,32 +1,35 @@
 -> This prints before the span open message
 1:main┐open: deferred::hierarchical-example version=0.1
-1:main├┐pre_open: deferred::hierarchical-example version=0.1
-1:main│└┐open(v): deferred::server host="localhost", port=8080
+1:main├─┐open: deferred::server host="localhost", port=8080
 1:main│ ├─  Xms INFO deferred starting
 1:main│ ├─  Xs  INFO deferred listening
 -> Deferring two levels of spans
-1:main│ ├─┐open: deferred::connections 
-1:main│ │ ├┐pre_open: deferred::connections 
-1:main│ │ │└┐open(v): deferred::conn peer_addr="82.9.9.9", port=42381
+1:main│ ├┐pre_open: deferred::server host="localhost", port=8080
+1:main│ │└┐open(v): deferred::connections 
+1:main│ │ ├─┐open: deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ │ ├─  Xms DEBUG deferred connected, peer="peer1"
 1:main│ │ │ ├─  Xms DEBUG deferred message received, length=2
 1:main│ │ │┌┘close(v): deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├─┐open: deferred::conn peer_addr="8.8.8.8", port=18230
+1:main│ │ ├┐pre_open: deferred::connections 
+1:main│ │ │└┐open(v): deferred::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ │ ├─  Xms DEBUG deferred connected, peer="peer3"
 1:main│ │ │┌┘close(v): deferred::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├─┐open: deferred::foomp 42 <- format string, normal_var=43
+1:main│ │ ├┐pre_open: deferred::connections 
+1:main│ │ │└┐open(v): deferred::foomp 42 <- format string, normal_var=43
 1:main│ │ │ ├─  Xms ERROR deferred hello
 1:main│ │ │┌┘close(v): deferred::foomp 42 <- format string, normal_var=43
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├─┐open: deferred::conn peer_addr="82.9.9.9", port=42381
+1:main│ │ ├┐pre_open: deferred::connections 
+1:main│ │ │└┐open(v): deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ │ ├─  Xms WARN deferred weak encryption requested, algo="xor"
 1:main│ │ │ ├─  Xms DEBUG deferred response sent, length=8
 1:main│ │ │ ├─  Xms DEBUG deferred disconnected
 1:main│ │ │┌┘close(v): deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├─┐open: deferred::conn peer_addr="8.8.8.8", port=18230
+1:main│ │ ├┐pre_open: deferred::connections 
+1:main│ │ │└┐open(v): deferred::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ │ ├─  Xms DEBUG deferred message received, length=5
 1:main│ │ │ ├─  Xms DEBUG deferred response sent, length=8
 1:main│ │ │ ├─  Xms DEBUG deferred disconnected

--- a/examples/deferred.stdout
+++ b/examples/deferred.stdout
@@ -1,35 +1,32 @@
 -> This prints before the span open message
-1:main┐open(v): deferred::hierarchical-example version=0.1
-1:main├─┐open: deferred::server host="localhost", port=8080
+1:main┐open: deferred::hierarchical-example version=0.1
+1:main├┐pre_open: deferred::hierarchical-example version=0.1
+1:main│└┐open(v): deferred::server host="localhost", port=8080
 1:main│ ├─  Xms INFO deferred starting
 1:main│ ├─  Xs  INFO deferred listening
 -> Deferring two levels of spans
-1:main│ ├┐pre_open: deferred::server host="localhost", port=8080
-1:main│ │└┐open(v): deferred::connections 
-1:main│ │ ├─┐open: deferred::conn peer_addr="82.9.9.9", port=42381
+1:main│ ├─┐open: deferred::connections 
+1:main│ │ ├┐pre_open: deferred::connections 
+1:main│ │ │└┐open(v): deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ │ ├─  Xms DEBUG deferred connected, peer="peer1"
 1:main│ │ │ ├─  Xms DEBUG deferred message received, length=2
 1:main│ │ │┌┘close(v): deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├┐pre_open: deferred::connections 
-1:main│ │ │└┐open(v): deferred::conn peer_addr="8.8.8.8", port=18230
+1:main│ │ ├─┐open: deferred::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ │ ├─  Xms DEBUG deferred connected, peer="peer3"
 1:main│ │ │┌┘close(v): deferred::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├┐pre_open: deferred::connections 
-1:main│ │ │└┐open(v): deferred::foomp 42 <- format string, normal_var=43
+1:main│ │ ├─┐open: deferred::foomp 42 <- format string, normal_var=43
 1:main│ │ │ ├─  Xms ERROR deferred hello
 1:main│ │ │┌┘close(v): deferred::foomp 42 <- format string, normal_var=43
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├┐pre_open: deferred::connections 
-1:main│ │ │└┐open(v): deferred::conn peer_addr="82.9.9.9", port=42381
+1:main│ │ ├─┐open: deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ │ ├─  Xms WARN deferred weak encryption requested, algo="xor"
 1:main│ │ │ ├─  Xms DEBUG deferred response sent, length=8
 1:main│ │ │ ├─  Xms DEBUG deferred disconnected
 1:main│ │ │┌┘close(v): deferred::conn peer_addr="82.9.9.9", port=42381
 1:main│ │ ├┘post_close: deferred::connections 
-1:main│ │ ├┐pre_open: deferred::connections 
-1:main│ │ │└┐open(v): deferred::conn peer_addr="8.8.8.8", port=18230
+1:main│ │ ├─┐open: deferred::conn peer_addr="8.8.8.8", port=18230
 1:main│ │ │ ├─  Xms DEBUG deferred message received, length=5
 1:main│ │ │ ├─  Xms DEBUG deferred response sent, length=8
 1:main│ │ │ ├─  Xms DEBUG deferred disconnected

--- a/src/format.rs
+++ b/src/format.rs
@@ -246,7 +246,7 @@ impl Buffers {
         }
 
         indent_block(
-            &mut self.current_buf,
+            &self.current_buf,
             &mut self.indent_buf,
             indent % config.wraparound,
             config.indent_amount,
@@ -479,7 +479,7 @@ fn indent_block_with_lines(
 }
 
 fn indent_block(
-    block: &mut String,
+    block: &str,
     buf: &mut String,
     mut indent: usize,
     indent_amount: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,10 +307,11 @@ where
                     false
                 };
 
-                let verbose = i == 1 && pre_open && span.id() == new_span_id;
-                // Print the parent of the new span if `pre_open==true`
-                if verbose {
+                // Print the parent of the first span
+                let mut verbose = false;
+                if i == 0 && pre_open {
                     if let Some(span) = span.parent() {
+                        verbose = true;
                         self.write_span_info(&span, bufs, SpanMode::PreOpen);
                     }
                 }


### PR DESCRIPTION
Fixes: #74 

Previously, spans were not retraced if they were printed by a nested span open event, as it was wrongfully assumed a span only printed once an event was generated by it, and not by its entering alone.

This further fixes `verbose_entry` combined with `retrace`, as the latter broke the indent line connectivity and only printed the immediate successor of the span, not the parent of the entered tree (as multiple spans can be entered at once during retracing)

```sh
1:main┐concurrent_eager::spawn_fut key="a"
1:main┐concurrent_eager::spawn_fut key="b"
1:main├───┐concurrent_eager::a 
1:main├───┘
1:main├───┐concurrent_eager::b 
1:main├───┘
1:main┘
1:main┘
```

This is now fixed, which means that `retrace=true, deferred=false` should now work properly for interleaved or multithreaded futures.

```sh
1:main┐concurrent_eager::spawn_fut key="a"
1:main┐concurrent_eager::spawn_fut key="b"
1:main┐concurrent_eager::spawn_fut key="a"
1:main├───┐concurrent_eager::a 
1:main├───┘
1:main┐concurrent_eager::spawn_fut key="b"
1:main├───┐concurrent_eager::b 
1:main├───┘
1:main┘
1:main┘
```