### PR TITLE
Add `on_record` to `support tracing::field::Empty` and `span.record`

### DIFF
--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -1,3 +1,4 @@
+use tracing::field::Empty;
 use tracing::{debug, error, info, level_filters::LevelFilter, span, trace, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry, Layer};
 use tracing_tree::HierarchicalLayer;
@@ -27,6 +28,13 @@ fn main() {
     let server_span = span!(Level::DEBUG, "server", host = "localhost", port = 8080);
 
     println!("-> This prints before the span open message");
+
+    let lazy = span!(Level::DEBUG, "lazy span", work_units = Empty);
+    lazy.record("work_units", &3);
+    lazy.in_scope(|| {
+        info!("doing some work");
+    });
+    drop(lazy);
 
     let _e2 = server_span.enter();
     info!("starting");

--- a/examples/deferred.stdout
+++ b/examples/deferred.stdout
@@ -1,8 +1,8 @@
 -> This prints before the span open message
 1:main┐open: deferred::hierarchical-example version=0.1
-1:main└─┐open: deferred::lazy span 
+1:main└─┐open: deferred::lazy span work_units=3
 1:main  ├─ INFO deferred doing some work
-1:main ┌┘close(v): deferred::lazy span 
+1:main ┌┘close(v): deferred::lazy span work_units=3
 1:main┌┘post_close: deferred::hierarchical-example version=0.1
 1:main└┐pre_open: deferred::hierarchical-example version=0.1
 1:main └┐open(v): deferred::server host="localhost", port=8080

--- a/examples/deferred.stdout
+++ b/examples/deferred.stdout
@@ -1,6 +1,11 @@
 -> This prints before the span open message
 1:main┐open: deferred::hierarchical-example version=0.1
-1:main└─┐open: deferred::server host="localhost", port=8080
+1:main└─┐open: deferred::lazy span 
+1:main  ├─ INFO deferred doing some work
+1:main ┌┘close(v): deferred::lazy span 
+1:main┌┘post_close: deferred::hierarchical-example version=0.1
+1:main└┐pre_open: deferred::hierarchical-example version=0.1
+1:main └┐open(v): deferred::server host="localhost", port=8080
 1:main  ├─ INFO deferred starting
 1:main  ├─ INFO deferred listening
 -> Deferring two levels of spans

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,6 +601,18 @@ where
             }
         }
     }
+
+    fn on_record(&self, id: &Id, values: &tracing_core::span::Record<'_>, ctx: Context<S>) {
+        let Some(_guard) = Self::is_recursive() else {
+            return;
+        };
+
+        if let Some(span) = ctx.span(id) {
+            if let Some(data) = span.extensions_mut().get_mut::<Data>() {
+                values.record(data);
+            }
+        }
+    }
 }
 
 fn scope_path<'a, R: LookupSpan<'a>>(span: &SpanRef<'a, R>) -> ScopeFromRoot<'a, R> {


### PR DESCRIPTION
Currently, when `tracing::field::Empty` is used with `span.record()` calls, the recorded values are lost and not displayed in span traces. This PR introduces `on_record` functionality to preserve and display recorded values.

```rust
let lazy = span!(Level::DEBUG, "lazy span", work_units = Empty);
lazy.record("work_units", &3);
lazy.in_scope(|| {
    info!("doing some work");
});
drop(lazy);
```

## Before

```
1:main└─┐open: deferred::lazy span 
1:main  ├─ INFO deferred doing some work
1:main ┌┘close(v): deferred::lazy span 
```

## After

```
1:main└─┐open: deferred::lazy span work_units=3
1:main  ├─ INFO deferred doing some work
1:main ┌┘close(v): deferred::lazy span work_units=3
```