### PR TITLE
fix clippy errors in example directory

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -88,16 +88,4 @@ fn main() {
     warn!("internal error");
     log::error!("this is a log message");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,6 +2,7 @@ use tracing::{debug, error, info, instrument, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct PrettyPrintMe {
     value_a: u32,
@@ -89,6 +90,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");

--- a/examples/basic_non_verbose.rs
+++ b/examples/basic_non_verbose.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -67,16 +67,4 @@ fn main() {
     warn!("internal error");
     log::error!("this is a log message");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/basic_non_verbose.rs
+++ b/examples/basic_non_verbose.rs
@@ -69,6 +69,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");

--- a/examples/basic_verbose_entry.rs
+++ b/examples/basic_verbose_entry.rs
@@ -71,6 +71,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");

--- a/examples/basic_verbose_entry.rs
+++ b/examples/basic_verbose_entry.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -69,16 +69,4 @@ fn main() {
     warn!("internal error");
     log::error!("this is a log message");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/basic_verbose_exit.rs
+++ b/examples/basic_verbose_exit.rs
@@ -71,6 +71,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");

--- a/examples/basic_verbose_exit.rs
+++ b/examples/basic_verbose_exit.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -69,16 +69,4 @@ fn main() {
     warn!("internal error");
     log::error!("this is a log message");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -99,6 +99,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");

--- a/examples/deferred.rs
+++ b/examples/deferred.rs
@@ -1,6 +1,4 @@
-use tracing::{
-    debug, error, info, instrument, level_filters::LevelFilter, span, trace, warn, Level,
-};
+use tracing::{debug, error, info, level_filters::LevelFilter, span, trace, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry, Layer};
 use tracing_tree::HierarchicalLayer;
 
@@ -97,16 +95,4 @@ fn main() {
     warn!("internal error");
     log::error!("this is a log message");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/no-indent.rs
+++ b/examples/no-indent.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -84,16 +84,4 @@ fn main() {
     drop(peer2);
     warn!("internal error");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/no-indent.rs
+++ b/examples/no-indent.rs
@@ -2,6 +2,7 @@ use tracing::{debug, error, info, instrument, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct PrettyPrintMe {
     value_a: u32,
@@ -85,6 +86,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");

--- a/examples/quiet.rs
+++ b/examples/quiet.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
 use tracing_tree::HierarchicalLayer;
 
@@ -66,16 +66,4 @@ fn main() {
     drop(peer2);
     warn!("internal error");
     info!("exit");
-}
-
-#[allow(dead_code)]
-#[instrument]
-fn call_a(name: &str) {
-    info!(name, "got a name");
-    call_b(name)
-}
-
-#[instrument]
-fn call_b(name: &str) {
-    info!(name, "got a name");
 }

--- a/examples/quiet.rs
+++ b/examples/quiet.rs
@@ -68,6 +68,7 @@ fn main() {
     info!("exit");
 }
 
+#[allow(dead_code)]
 #[instrument]
 fn call_a(name: &str) {
     info!(name, "got a name");


### PR DESCRIPTION
should id add `#[allow(dead_code)]` or remove functions? What do you think about struct fields?